### PR TITLE
API 문서 페이지에 상단 네비게이션 바 추가

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -6,5 +6,6 @@ use CodeIgniter\Router\RouteCollection;
  * @var RouteCollection $routes
  */
 $routes->get('/', 'Home::index');
+$routes->get('docs/api', 'Docs::api');
 
 service('auth')->routes($routes);

--- a/app/Controllers/Docs.php
+++ b/app/Controllers/Docs.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Controllers;
+
+class Docs extends BaseController
+{
+    public function api(): string
+    {
+        return view('docs/api');
+    }
+}

--- a/app/Views/docs/api.php
+++ b/app/Views/docs/api.php
@@ -1,0 +1,110 @@
+<?= $this->extend('layouts/default') ?>
+
+<?= $this->section('title') ?>API 문서<?= $this->endSection() ?>
+
+<?= $this->section('head') ?>
+<style>
+    /*
+     * Redoc CSS 격리: Tailwind preflight가 Redoc 내부 요소에 영향을 주지 않도록
+     * 브라우저 기본 스타일을 복원합니다.
+     */
+    #redoc-container {
+        background: #ffffff;
+        color: #333333;
+    }
+    #redoc-container h1, #redoc-container h2, #redoc-container h3,
+    #redoc-container h4, #redoc-container h5, #redoc-container h6 {
+        font-size: revert;
+        font-weight: revert;
+    }
+    #redoc-container p, #redoc-container ul, #redoc-container ol,
+    #redoc-container li, #redoc-container table, #redoc-container pre,
+    #redoc-container code, #redoc-container blockquote {
+        margin: revert;
+        padding: revert;
+    }
+    #redoc-container ul, #redoc-container ol {
+        list-style: revert;
+    }
+    #redoc-container a {
+        color: revert;
+        text-decoration: revert;
+    }
+    #redoc-container img, #redoc-container svg {
+        display: revert;
+        vertical-align: revert;
+    }
+    #redoc-container table {
+        border-collapse: revert;
+    }
+    #redoc-container hr {
+        border-top-width: revert;
+    }
+    #redoc-container button, #redoc-container input,
+    #redoc-container select, #redoc-container textarea {
+        font-family: revert;
+        font-size: revert;
+        color: revert;
+    }
+</style>
+<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+<div id="redoc-container"></div>
+<?= $this->endSection() ?>
+
+<?= $this->section('scripts') ?>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+<script>
+    Redoc.init(
+        '<?= base_url('docs/openapi.yaml') ?>',
+        {
+            scrollYOffset: function() {
+                return document.querySelector('.navbar').offsetHeight;
+            },
+            hideDownloadButton: false,
+            disableSearch: false,
+            theme: {
+                colors: {
+                    primary: {
+                        main: '#DD4814'
+                    }
+                },
+                typography: {
+                    fontSize: '15px',
+                    fontFamily: '"Noto Sans KR", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+                    headings: {
+                        fontFamily: '"Noto Sans KR", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+                        fontWeight: '600'
+                    },
+                    code: {
+                        fontSize: '14px',
+                        fontFamily: '"Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace'
+                    }
+                },
+                sidebar: {
+                    backgroundColor: '#fafafa',
+                    textColor: '#333',
+                    activeTextColor: '#DD4814'
+                },
+                rightPanel: {
+                    backgroundColor: '#263238',
+                    textColor: '#ffffff'
+                }
+            },
+            nativeScrollbars: false,
+            expandResponses: '200,201',
+            requiredPropsFirst: true,
+            sortPropsAlphabetically: false,
+            showExtensions: true,
+            pathInMiddlePanel: false,
+            hideHostname: false,
+            expandSingleSchemaField: true,
+            jsonSampleExpandLevel: 2,
+            hideSingleRequestSampleTab: true,
+            menuToggle: true
+        },
+        document.getElementById('redoc-container')
+    );
+</script>
+<?= $this->endSection() ?>

--- a/app/Views/home.php
+++ b/app/Views/home.php
@@ -27,7 +27,7 @@
                 <ul class="menu menu-horizontal px-1">
                     <li><a href="#features" class="text-nord-6 hover:text-nord-8">기능</a></li>
                     <li><a href="#architecture" class="text-nord-6 hover:text-nord-8">아키텍처</a></li>
-                    <li><a href="/docs/api-docs.html" class="text-nord-6 hover:text-nord-8">API 문서</a></li>
+                    <li><a href="/docs/api" class="text-nord-6 hover:text-nord-8">API 문서</a></li>
                     <li><a href="/login" class="btn-login">로그인</a></li>
                 </ul>
             </div>
@@ -57,7 +57,7 @@
         <ul class="mobile-menu-list">
             <li><a href="#features" class="mobile-menu-link">기능</a></li>
             <li><a href="#architecture" class="mobile-menu-link">아키텍처</a></li>
-            <li><a href="/docs/api-docs.html" class="mobile-menu-link">API 문서</a></li>
+            <li><a href="/docs/api" class="mobile-menu-link">API 문서</a></li>
             <li class="mt-4 px-2">
                 <a href="/login" class="btn btn-primary btn-block">로그인</a>
             </li>
@@ -309,7 +309,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
                         </svg>
                     </a>
-                    <a href="/docs/api-docs.html" class="btn btn-ghost btn-lg text-nord-2 hover:text-nord-0 hover:bg-nord-6">
+                    <a href="/docs/api" class="btn btn-ghost btn-lg text-nord-2 hover:text-nord-0 hover:bg-nord-6">
                         API 문서 보기
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />

--- a/app/Views/layouts/default.php
+++ b/app/Views/layouts/default.php
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="ko" data-theme="nord">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= $this->renderSection('title') ?> - CI4 CMS</title>
+    <link rel="shortcut icon" href="<?= base_url('logo.svg') ?>" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="<?= base_url('/assets/css/output.css') ?>" rel="stylesheet">
+    <?= $this->renderSection('head') ?>
+</head>
+<body class="min-h-screen">
+
+    <!-- Navigation -->
+    <nav class="navbar bg-nord-1/95 backdrop-blur-sm shadow-nord sticky top-0 z-50">
+        <div class="container mx-auto px-4">
+            <div class="flex-1">
+                <a href="/" class="btn btn-ghost normal-case text-xl text-nord-8 hover:text-nord-7">
+                    <img src="<?= base_url('assets/images/logo.svg') ?>" alt="CI4 CMS Logo" class="h-6 inline-block align-middle mr-2">
+                    CI4 CMS
+                </a>
+            </div>
+            <!-- Desktop Menu -->
+            <div class="flex-none hidden md:block">
+                <ul class="menu menu-horizontal px-1">
+                    <li><a href="/#features" class="text-nord-6 hover:text-nord-8">기능</a></li>
+                    <li><a href="/#architecture" class="text-nord-6 hover:text-nord-8">아키텍처</a></li>
+                    <li><a href="/docs/api" class="text-nord-6 hover:text-nord-8">API 문서</a></li>
+                    <li><a href="/login" class="btn-login">로그인</a></li>
+                </ul>
+            </div>
+            <!-- Mobile Hamburger Button -->
+            <div class="flex-none md:hidden">
+                <button
+                    id="mobile-menu-toggle"
+                    class="hamburger-btn"
+                    type="button"
+                    aria-label="메뉴 열기"
+                    aria-expanded="false"
+                    aria-controls="mobile-menu"
+                >
+                    <span class="hamburger-line hamburger-line-1"></span>
+                    <span class="hamburger-line hamburger-line-2"></span>
+                    <span class="hamburger-line hamburger-line-3"></span>
+                </button>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Mobile Menu Overlay -->
+    <div id="mobile-menu-overlay" class="mobile-overlay" aria-hidden="true"></div>
+
+    <!-- Mobile Menu -->
+    <nav id="mobile-menu" class="mobile-menu" aria-label="모바일 메뉴" aria-hidden="true" inert>
+        <ul class="mobile-menu-list">
+            <li><a href="/#features" class="mobile-menu-link">기능</a></li>
+            <li><a href="/#architecture" class="mobile-menu-link">아키텍처</a></li>
+            <li><a href="/docs/api" class="mobile-menu-link">API 문서</a></li>
+            <li class="mt-4 px-2">
+                <a href="/login" class="btn btn-primary btn-block">로그인</a>
+            </li>
+        </ul>
+    </nav>
+
+    <!-- Main Content -->
+    <?= $this->renderSection('content') ?>
+
+    <!-- Footer -->
+    <footer class="footer footer-center p-10 bg-nord-1 text-nord-4">
+        <div>
+            <div class="font-bold leading-tight text-nord-6">
+                <div class="flex items-center justify-center">
+                    <img src="<?= base_url('assets/images/logo.svg') ?>" alt="logo" class="w-10 h-10 mx-auto inline-block mr-2">
+                    <span class="text-lg">CI4 CMS</span>
+                </div>
+            </div>
+            <p class="text-sm leading-normal">Copyright &copy; <?= date('Y') ?> - All rights reserved</p>
+        </div>
+    </footer>
+
+    <!-- Navbar Scroll Effect & Mobile Menu Script -->
+    <script>
+        (function() {
+            // === Navbar Scroll Effect ===
+            const nav = document.querySelector('.navbar');
+            if (nav) {
+                let ticking = false;
+                function updateNavbar() {
+                    if (window.scrollY > 50) {
+                        nav.classList.add('scrolled');
+                    } else {
+                        nav.classList.remove('scrolled');
+                    }
+                    ticking = false;
+                }
+                window.addEventListener('scroll', function() {
+                    if (!ticking) {
+                        window.requestAnimationFrame(updateNavbar);
+                        ticking = true;
+                    }
+                });
+                updateNavbar();
+            }
+
+            // === Mobile Menu ===
+            const toggle = document.getElementById('mobile-menu-toggle');
+            const menu = document.getElementById('mobile-menu');
+            const overlay = document.getElementById('mobile-menu-overlay');
+            if (!toggle || !menu || !overlay) return;
+
+            function openMenu() {
+                toggle.classList.add('active');
+                menu.classList.add('active');
+                overlay.classList.add('active');
+                toggle.setAttribute('aria-expanded', 'true');
+                toggle.setAttribute('aria-label', '메뉴 닫기');
+                menu.setAttribute('aria-hidden', 'false');
+                overlay.setAttribute('aria-hidden', 'false');
+                document.getElementById('mobile-menu').inert = false;
+                document.body.style.overflow = 'hidden';
+            }
+
+            function closeMenu() {
+                toggle.classList.remove('active');
+                menu.classList.remove('active');
+                overlay.classList.remove('active');
+                toggle.setAttribute('aria-expanded', 'false');
+                toggle.setAttribute('aria-label', '메뉴 열기');
+                menu.setAttribute('aria-hidden', 'true');
+                overlay.setAttribute('aria-hidden', 'true');
+                document.getElementById('mobile-menu').inert = true;
+                document.body.style.overflow = '';
+            }
+
+            function isOpen() {
+                return menu.classList.contains('active');
+            }
+
+            toggle.addEventListener('click', function() {
+                isOpen() ? closeMenu() : openMenu();
+            });
+
+            overlay.addEventListener('click', closeMenu);
+
+            document.addEventListener('keydown', function(e) {
+                if (e.key === 'Escape' && isOpen()) {
+                    closeMenu();
+                    toggle.focus();
+                }
+            });
+
+            menu.querySelectorAll('a').forEach(function(link) {
+                link.addEventListener('click', closeMenu);
+            });
+
+            window.addEventListener('resize', function() {
+                if (window.innerWidth >= 768 && isOpen()) {
+                    closeMenu();
+                }
+            });
+        })();
+    </script>
+
+    <?= $this->renderSection('scripts') ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- default 레이아웃 템플릿(`layouts/default.php`) 생성하여 navbar + 모바일 메뉴 공유 구조 마련
- API 문서를 정적 HTML에서 CI4 뷰(`docs/api.php`)로 전환, 레이아웃 extend 방식 적용
- Redoc CSS 격리 스타일 추가로 Tailwind preflight와의 충돌 방지
- 홈페이지 API 문서 링크를 `/docs/api` 라우트로 변경 (데스크탑/모바일/CTA 3곳)

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `app/Views/layouts/default.php` | 신규 - 공통 레이아웃 (navbar, 모바일 메뉴, footer) |
| `app/Views/docs/api.php` | 신규 - Redoc API 문서 뷰 (CSS 격리 포함) |
| `app/Controllers/Docs.php` | 신규 - 문서 컨트롤러 |
| `app/Config/Routes.php` | `GET /docs/api` 라우트 추가 |
| `app/Views/home.php` | API 문서 링크 3곳 경로 변경 |

## Test plan
- [x] 데스크탑에서 `/docs/api` 접속 시 navbar + Redoc 정상 렌더링
- [x] 모바일에서 햄버거 메뉴 정상 동작
- [x] 홈페이지 navbar에서 "API 문서" 클릭 시 `/docs/api`로 이동
- [x] Redoc 스타일이 Tailwind CSS에 영향받지 않음 (배경 흰색, 텍스트 가독성)
- [ ] `/docs/api`에서 CI4 CMS 로고 클릭 시 홈으로 이동

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 새로운 API 문서 페이지 추가 (/docs/api)
  * 대화형 API 문서 뷰어(Redoc) 통합으로 OpenAPI 사양 지원
  * 네비게이션 메뉴의 API 문서 링크 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->