### PR TITLE
✨ feat: CategoriesController CRUD 구현 및 SlugGeneratorTrait 추출

### DIFF
--- a/app/Controllers/Api/V1/BaseApiController.php
+++ b/app/Controllers/Api/V1/BaseApiController.php
@@ -114,9 +114,13 @@ abstract class BaseApiController extends ResourceController
     protected function failOnModelError(): ResponseInterface
     {
         if (empty($this->model->errors())) {
-            $errorMessage = $this->model->db->error()['message'] ?? json_encode($this->model->db->error());
+            log_message('error', $this->model->db->error()['message']);
 
-            return $this->failServerError($errorMessage);
+            if ($this->model->db->error()['code'] == 1062) {
+                return $this->failValidationErrors('Duplicate entry');
+            }
+
+            return $this->failServerError('Database error');
         } else {
             return $this->failValidationErrors($this->model->errors());
         }

--- a/app/Controllers/Api/V1/BaseApiController.php
+++ b/app/Controllers/Api/V1/BaseApiController.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace App\Controllers\Api\V1;
 
-use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\Model;
+use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\RESTful\ResourceController;
-use CodeIgniter\Shield\Entities\User;
+use CodeIgniter\Exceptions\PageNotFoundException;
 
 /**
  * API V1 공통 기반 컨트롤러
@@ -91,8 +92,7 @@ abstract class BaseApiController extends ResourceController
         ]);
     }
 
-    protected function failValidationErrors(mixed  $errors, ?string $code = null,
-                                            string $message = ''): ResponseInterface
+    protected function failValidationErrors(mixed  $errors, ?string $code = null, string $message = ''): ResponseInterface
     {
         return $this->respond([
             'status'  => 'error',
@@ -102,13 +102,23 @@ abstract class BaseApiController extends ResourceController
         ], 422);
     }
 
-    protected function failNotFound(string $description = 'Not Found', ?string $code = null,
-                                    string $message = ''): ResponseInterface
+    protected function failNotFound(string $description = 'Not Found', ?string $code = null, string $message = ''): ResponseInterface
     {
         return $this->respond([
             'status'  => 'error',
             'code'    => $this->codes['resource_not_found'],
             'message' => $description,
         ], 404);
+    }
+
+    protected function failOnModelError(): ResponseInterface
+    {
+        if (empty($this->model->errors())) {
+            $errorMessage = $this->model->db->error()['message'] ?? json_encode($this->model->db->error());
+
+            return $this->failServerError($errorMessage);
+        } else {
+            return $this->failValidationErrors($this->model->errors());
+        }
     }
 }

--- a/app/Controllers/Api/V1/BaseApiController.php
+++ b/app/Controllers/Api/V1/BaseApiController.php
@@ -110,19 +110,4 @@ abstract class BaseApiController extends ResourceController
             'message' => $description,
         ], 404);
     }
-
-    protected function failOnModelError(): ResponseInterface
-    {
-        if (empty($this->model->errors())) {
-            log_message('error', $this->model->db->error()['message']);
-
-            if ($this->model->db->error()['code'] == 1062) {
-                return $this->failValidationErrors('Duplicate entry');
-            }
-
-            return $this->failServerError('Database error');
-        } else {
-            return $this->failValidationErrors($this->model->errors());
-        }
-    }
 }

--- a/app/Controllers/Api/V1/CategoriesController.php
+++ b/app/Controllers/Api/V1/CategoriesController.php
@@ -90,15 +90,15 @@ class CategoriesController extends BaseApiController
         }
 
         $payload = $this->request->getJSON(true);
-
-        if (!$this->validateData($payload, $this->rules)) {
-            return $this->failValidationErrors($this->validator->getErrors());
-        }
-
         $allowedPayload = array_intersect_key($payload, $this->rules);
+        $updateRules = array_intersect_key($this->rules, $allowedPayload);
 
         if (!$allowedPayload) {
             return $this->failValidationErrors('No valid data provided');
+        }
+
+        if (!$this->validateData($allowedPayload, $updateRules)) {
+            return $this->failValidationErrors($this->validator->getErrors());
         }
 
         $result = $this->model->update($id, $allowedPayload);
@@ -141,6 +141,7 @@ class CategoriesController extends BaseApiController
 
         $posts = model('PostModel')
             ->where('category_id', $id)
+            ->where('tenant_id', $category->tenant_id)
             ->where('state', 'published')
             ->findAll();
 

--- a/app/Controllers/Api/V1/CategoriesController.php
+++ b/app/Controllers/Api/V1/CategoriesController.php
@@ -33,18 +33,18 @@ class CategoriesController extends BaseApiController
         $this->transformer = new CategoryTransformer();
     }
 
-    #[Cache(for: 10 * MINUTE)]
+    #[Filter(by: 'tokens')]
     public function index(): ResponseInterface
     {
-        $categories = $this->model->findAll();
+        $categories = $this->model->where('tenant_id', auth()->user()->tenant_id)->findAll();
 
         return $this->responseWith($this->transformer->transformMany($categories));
     }
 
-    #[Cache(for: 10 * MINUTE)]
+    #[Filter(by: 'tokens')]
     public function show($id = null): ResponseInterface
     {
-        $category = $this->model->find($id);
+        $category = $this->model->where('tenant_id', auth()->user()->tenant_id)->find($id);
 
         if ($category === null) {
             return $this->failNotFound();
@@ -97,6 +97,10 @@ class CategoriesController extends BaseApiController
             return $this->failNotFound("Category not found: $id");
         }
 
+        if ((int)$category->tenant_id !== (int)auth()->user()->tenant_id) {
+            return $this->failForbidden('You are not authorized to update this category');
+        }
+
         $payload = $this->request->getJSON(true);
 
         if (!$payload) {
@@ -137,6 +141,10 @@ class CategoriesController extends BaseApiController
             return $this->failNotFound("Category not found: $id");
         }
 
+        if ((int)$category->tenant_id !== (int)auth()->user()->tenant_id) {
+            return $this->failForbidden('You are not authorized to delete this category');
+        }
+
         try {
             $this->model->delete($id);
         } catch (DatabaseException $exception) {
@@ -147,9 +155,10 @@ class CategoriesController extends BaseApiController
         return $this->respondNoContent();
     }
 
+    #[Filter(by: 'tokens')]
     public function posts($id = null): ResponseInterface
     {
-        $category = $this->model->find($id);
+        $category = $this->model->where('tenant_id', auth()->user()->tenant_id)->find($id);
 
         if (!$category) {
             return $this->failNotFound("Category not found: $id");
@@ -157,7 +166,7 @@ class CategoriesController extends BaseApiController
 
         $posts = model('PostModel')
             ->where('category_id', $id)
-            ->where('tenant_id', $category->tenant_id)
+            ->where('tenant_id', auth()->user()->tenant_id)
             ->where('state', 'published')
             ->findAll();
 

--- a/app/Controllers/Api/V1/CategoriesController.php
+++ b/app/Controllers/Api/V1/CategoriesController.php
@@ -91,14 +91,12 @@ class CategoriesController extends BaseApiController
     #[Filter(by: 'permission', having: ['categories.manage'])]
     public function update($id = null): ResponseInterface
     {
-        $category = $this->model->find($id);
+        $category = $this->model
+            ->where('tenant_id', auth()->user()->tenant_id)
+            ->find($id);
 
         if (!$category) {
             return $this->failNotFound("Category not found: $id");
-        }
-
-        if ((int)$category->tenant_id !== (int)auth()->user()->tenant_id) {
-            return $this->failForbidden('You are not authorized to update this category');
         }
 
         $payload = $this->request->getJSON(true);
@@ -135,14 +133,12 @@ class CategoriesController extends BaseApiController
     #[Filter(by: 'permission', having: ['categories.manage'])]
     public function delete($id = null): ResponseInterface
     {
-        $category = $this->model->find($id);
+        $category = $this->model
+            ->where('tenant_id', auth()->user()->tenant_id)
+            ->find($id);
 
         if (!$category) {
             return $this->failNotFound("Category not found: $id");
-        }
-
-        if ((int)$category->tenant_id !== (int)auth()->user()->tenant_id) {
-            return $this->failForbidden('You are not authorized to delete this category');
         }
 
         try {

--- a/app/Controllers/Api/V1/CategoriesController.php
+++ b/app/Controllers/Api/V1/CategoriesController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controllers\Api\V1;
 
+use App\Models\CategoryModel;
 use App\Transformers\CategoryTransformer;
 use App\Transformers\PostTransformer;
 use CodeIgniter\HTTP\ResponseInterface;
@@ -19,6 +20,8 @@ use CodeIgniter\Router\Attributes\Filter;
 class CategoriesController extends BaseApiController
 {
     protected CategoryTransformer $transformer;
+    protected $modelName = CategoryModel::class;
+    protected $format = 'json';
 
     public function __construct()
     {
@@ -28,52 +31,138 @@ class CategoriesController extends BaseApiController
     #[Cache(for: 10 * MINUTE)]
     public function index(): ResponseInterface
     {
-        // TODO: $categories = model('CategoryModel')->findAll();
-        // return $this->respond($this->transformer->transformMany($categories));
-        return $this->fail('Not Implemented', 501);
+        $categories = $this->model->findAll();
+
+        return $this->responseWith($this->transformer->transformMany($categories));
     }
 
     #[Cache(for: 10 * MINUTE)]
     public function show($id = null): ResponseInterface
     {
-        // TODO: $category = model('CategoryModel')->find($id);
-        // if ($category === null) { return $this->failNotFound(); }
-        // return $this->respond($this->transformer->transform($category));
-        return $this->fail('Not Implemented', 501);
+        $category = $this->model->find($id);
+
+        if ($category === null) {
+            return $this->failNotFound();
+        }
+
+        return $this->respond($this->transformer->transform($category));
     }
 
     #[Filter(by: 'tokens')]
     #[Filter(by: 'permission', having: ['categories.manage'])]
     public function create(): ResponseInterface
     {
-        // TODO: validate, model save, return transformer result
-        // return $this->respondCreated($this->transformer->transform($category));
-        return $this->fail('Not Implemented', 501);
+        $rules = [
+            'name' => 'required|min_length[3]|max_length[255]|is_unique[categories.name]',
+            'description' => 'permit_empty|min_length[3]|max_length[255]',
+        ];
+
+        $payload = $this->request->getJSON(true);
+
+        if (!$payload) {
+            return $this->failValidationErrors('Invalid payload');
+        }
+
+        if (!$this->validateData($payload, $rules)) {
+            return $this->failValidationErrors($this->validator->getErrors());
+        }
+
+        $payload['tenant_id'] = auth()->user()->tenant_id;
+
+        $result = $this->model->insert($payload);
+
+        if (!$result) {
+            if (empty($this->model->errors())) {
+                return $this->failServerError($this->model->db->error());
+            } else {
+                return $this->failValidationErrors($this->model->errors());
+            }
+        }
+
+        $createdCategory = $this->model->find($this->model->getInsertID());
+
+        return $this->respondCreated($this->transformer->transform($createdCategory));
     }
 
     #[Filter(by: 'tokens')]
     #[Filter(by: 'permission', having: ['categories.manage'])]
     public function update($id = null): ResponseInterface
     {
-        // TODO: validate, model update, return transformer result
-        // return $this->respond($this->transformer->transform($category));
-        return $this->fail('Not Implemented', 501);
+        $category = $this->model->find($id);
+
+        if (!$category) {
+            return $this->failNotFound("Category not found: $id");
+        }
+
+        $rules = [
+            'name' => 'required|min_length[3]|max_length[255]|is_unique[categories.name,id,' . $id . ']',
+            'description' => 'permit_empty|min_length[3]|max_length[255]',
+        ];
+
+        $payload = $this->request->getJSON(true);
+
+        if (!$this->validateData($payload, $rules)) {
+            return $this->failValidationErrors($this->validator->getErrors());
+        }
+
+        $allowedPayload = array_intersect_key($payload, $rules);
+
+        if (!$allowedPayload) {
+            return $this->failValidationErrors('No valid data provided');
+        }
+
+        $result = $this->model->update($id, $allowedPayload);
+
+        if (!$result) {
+            if (empty($this->model->errors())) {
+                return $this->failServerError($this->model->db->error());
+            } else {
+                return $this->failValidationErrors($this->model->errors());
+            }
+        }
+
+        $updatedCategory = $this->model->find($id);
+
+        return $this->responseWithItem($this->transformer->transform($updatedCategory));
     }
 
     #[Filter(by: 'tokens')]
     #[Filter(by: 'permission', having: ['categories.manage'])]
     public function delete($id = null): ResponseInterface
     {
-        // TODO: model delete
-        // return $this->respondDeleted(['id' => $id]);
-        return $this->fail('Not Implemented', 501);
+        $category = $this->model->find($id);
+
+        if (!$category) {
+            return $this->failNotFound("Category not found: $id");
+        }
+
+        $result = $this->model->delete($id);
+
+        if (!$result) {
+            if (empty($this->model->errors())) {
+                return $this->failServerError($this->model->db->error());
+            } else {
+                return $this->failValidationErrors($this->model->errors());
+            }
+        }
+
+        return $this->respondNoContent();
     }
 
-    #[Cache(for: 5 * MINUTE)]
     public function posts($id = null): ResponseInterface
     {
-        // TODO: $posts = model('PostModel')->where('category_id', $id)->findAll();
-        // return $this->respond((new PostTransformer())->transformMany($posts));
-        return $this->fail('Not Implemented', 501);
+        $category = $this->model->find($id);
+
+        if (!$category) {
+            return $this->failNotFound("Category not found: $id");
+        }
+
+        $posts = model('PostModel')
+            ->where('category_id', $id)
+            ->where('state', 'published')
+            ->findAll();
+
+        return $this->respond((new PostTransformer())->transformMany($posts));
     }
+
 }

--- a/app/Controllers/Api/V1/CategoriesController.php
+++ b/app/Controllers/Api/V1/CategoriesController.php
@@ -7,6 +7,7 @@ namespace App\Controllers\Api\V1;
 use App\Models\CategoryModel;
 use App\Transformers\CategoryTransformer;
 use App\Transformers\PostTransformer;
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Router\Attributes\Cache;
 use CodeIgniter\Router\Attributes\Filter;
@@ -59,19 +60,26 @@ class CategoriesController extends BaseApiController
         $payload = $this->request->getJSON(true);
 
         if (!$payload) {
+            return $this->failValidationErrors('No payload provided');
+        }
+
+        $allowedPayload = array_intersect_key($payload, $this->rules);
+
+        if (!$allowedPayload) {
             return $this->failValidationErrors('Invalid payload');
         }
 
-        if (!$this->validateData($payload, $this->rules)) {
+        if (!$this->validateData($allowedPayload, $this->rules)) {
             return $this->failValidationErrors($this->validator->getErrors());
         }
 
-        $payload['tenant_id'] = auth()->user()->tenant_id;
+        $allowedPayload['tenant_id'] = auth()->user()->tenant_id;
 
-        $result = $this->model->insert($payload);
-
-        if (!$result) {
-            return $this->failOnModelError();
+        try {
+            $this->model->insert($allowedPayload);
+        } catch (DatabaseException $exception) {
+            log_message('error', $exception->getMessage());
+            return $this->failServerError('Database error');
         }
 
         $createdCategory = $this->model->find($this->model->getInsertID());
@@ -90,21 +98,28 @@ class CategoriesController extends BaseApiController
         }
 
         $payload = $this->request->getJSON(true);
+
+        if (!$payload) {
+            return $this->failValidationErrors('No payload provided');
+        }
+
         $allowedPayload = array_intersect_key($payload, $this->rules);
-        $updateRules = array_intersect_key($this->rules, $allowedPayload);
 
         if (!$allowedPayload) {
             return $this->failValidationErrors('No valid data provided');
         }
 
+        $updateRules = array_intersect_key($this->rules, $allowedPayload);
+
         if (!$this->validateData($allowedPayload, $updateRules)) {
             return $this->failValidationErrors($this->validator->getErrors());
         }
 
-        $result = $this->model->update($id, $allowedPayload);
-
-        if (!$result) {
-            return $this->failOnModelError();
+        try {
+            $this->model->update($id, $allowedPayload);
+        } catch (DatabaseException $exception) {
+            log_message('error', $exception->getMessage());
+            return $this->failServerError('Database error');
         }
 
         $updatedCategory = $this->model->find($id);
@@ -122,10 +137,11 @@ class CategoriesController extends BaseApiController
             return $this->failNotFound("Category not found: $id");
         }
 
-        $result = $this->model->delete($id);
-
-        if (!$result) {
-            return $this->failOnModelError();
+        try {
+            $this->model->delete($id);
+        } catch (DatabaseException $exception) {
+            log_message('error', $exception->getMessage());
+            return $this->failServerError('Database error');
         }
 
         return $this->respondNoContent();

--- a/app/Controllers/Api/V1/CategoriesController.php
+++ b/app/Controllers/Api/V1/CategoriesController.php
@@ -22,6 +22,10 @@ class CategoriesController extends BaseApiController
     protected CategoryTransformer $transformer;
     protected $modelName = CategoryModel::class;
     protected $format = 'json';
+    protected $rules = [
+        'name'        => 'required|min_length[3]|max_length[255]',
+        'description' => 'permit_empty|min_length[3]|max_length[255]',
+    ];
 
     public function __construct()
     {
@@ -52,18 +56,13 @@ class CategoriesController extends BaseApiController
     #[Filter(by: 'permission', having: ['categories.manage'])]
     public function create(): ResponseInterface
     {
-        $rules = [
-            'name' => 'required|min_length[3]|max_length[255]|is_unique[categories.name]',
-            'description' => 'permit_empty|min_length[3]|max_length[255]',
-        ];
-
         $payload = $this->request->getJSON(true);
 
         if (!$payload) {
             return $this->failValidationErrors('Invalid payload');
         }
 
-        if (!$this->validateData($payload, $rules)) {
+        if (!$this->validateData($payload, $this->rules)) {
             return $this->failValidationErrors($this->validator->getErrors());
         }
 
@@ -72,11 +71,7 @@ class CategoriesController extends BaseApiController
         $result = $this->model->insert($payload);
 
         if (!$result) {
-            if (empty($this->model->errors())) {
-                return $this->failServerError($this->model->db->error());
-            } else {
-                return $this->failValidationErrors($this->model->errors());
-            }
+            return $this->failOnModelError();
         }
 
         $createdCategory = $this->model->find($this->model->getInsertID());
@@ -94,18 +89,13 @@ class CategoriesController extends BaseApiController
             return $this->failNotFound("Category not found: $id");
         }
 
-        $rules = [
-            'name' => 'required|min_length[3]|max_length[255]|is_unique[categories.name,id,' . $id . ']',
-            'description' => 'permit_empty|min_length[3]|max_length[255]',
-        ];
-
         $payload = $this->request->getJSON(true);
 
-        if (!$this->validateData($payload, $rules)) {
+        if (!$this->validateData($payload, $this->rules)) {
             return $this->failValidationErrors($this->validator->getErrors());
         }
 
-        $allowedPayload = array_intersect_key($payload, $rules);
+        $allowedPayload = array_intersect_key($payload, $this->rules);
 
         if (!$allowedPayload) {
             return $this->failValidationErrors('No valid data provided');
@@ -114,11 +104,7 @@ class CategoriesController extends BaseApiController
         $result = $this->model->update($id, $allowedPayload);
 
         if (!$result) {
-            if (empty($this->model->errors())) {
-                return $this->failServerError($this->model->db->error());
-            } else {
-                return $this->failValidationErrors($this->model->errors());
-            }
+            return $this->failOnModelError();
         }
 
         $updatedCategory = $this->model->find($id);
@@ -139,11 +125,7 @@ class CategoriesController extends BaseApiController
         $result = $this->model->delete($id);
 
         if (!$result) {
-            if (empty($this->model->errors())) {
-                return $this->failServerError($this->model->db->error());
-            } else {
-                return $this->failValidationErrors($this->model->errors());
-            }
+            return $this->failOnModelError();
         }
 
         return $this->respondNoContent();

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -121,7 +121,11 @@ class PostsController extends BaseApiController
         $result = $this->model->insert($payload);
 
         if (!$result) {
-            return $this->failValidationErrors($this->model->errors());
+            if (empty($this->model->errors())) {
+                return $this->failServerError($this->model->db->error());
+            } else {
+                return $this->failValidationErrors($this->model->errors());
+            }
         }
 
         $createdPost = $this->model->find($this->model->getInsertID());

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -121,11 +121,7 @@ class PostsController extends BaseApiController
         $result = $this->model->insert($payload);
 
         if (!$result) {
-            if (empty($this->model->errors())) {
-                return $this->failServerError($this->model->db->error());
-            } else {
-                return $this->failValidationErrors($this->model->errors());
-            }
+            return $this->failOnModelError();
         }
 
         $createdPost = $this->model->find($this->model->getInsertID());

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -8,6 +8,7 @@ use App\Entities\PostEntity;
 use App\Enums\UserRole;
 use App\Models\PostModel;
 use App\Transformers\PostTransformer;
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Router\Attributes\Filter;
 
@@ -42,8 +43,8 @@ class PostsController extends BaseApiController
     public function index(): ResponseInterface
     {
         $rules = [
-            'per_page'     => 'permit_empty|integer|greater_than_equal_to[1]|less_than_equal_to[100]',
-            'search'     => 'permit_empty|string|max_length[255]',
+            'per_page'    => 'permit_empty|integer|greater_than_equal_to[1]|less_than_equal_to[100]',
+            'search'      => 'permit_empty|string|max_length[255]',
             'category_id' => 'permit_empty|integer',
         ];
 
@@ -118,10 +119,12 @@ class PostsController extends BaseApiController
         $payload['writer_id'] = auth()->id();
         $payload['state'] = 'draft';
         $payload['tenant_id'] = auth()->user()->tenant_id;
-        $result = $this->model->insert($payload);
 
-        if (!$result) {
-            return $this->failOnModelError();
+        try {
+            $this->model->insert($payload);
+        } catch (DatabaseException $exception) {
+            log_message('error', $exception->getMessage());
+            return $this->failServerError('Database error');
         }
 
         $createdPost = $this->model->find($this->model->getInsertID());
@@ -165,11 +168,13 @@ class PostsController extends BaseApiController
             return $this->failValidationErrors('No valid data provided');
         }
 
-        $result = $this->model->update($id, $allowedPayload);
-
-        if (!$result) {
-            return $this->failValidationErrors($this->model->errors());
+        try {
+            $this->model->update($id, $allowedPayload);
+        } catch (DatabaseException $exception) {
+            log_message('error', $exception->getMessage());
+            return $this->failServerError('Database error');
         }
+
 
         $updatedPost = $this->model->find($id);
 

--- a/app/Database/Migrations/2026-03-05-092000_CreateCategoriesTable.php
+++ b/app/Database/Migrations/2026-03-05-092000_CreateCategoriesTable.php
@@ -21,6 +21,7 @@ class CreateCategoriesTable extends Migration
         $this->forge->addPrimaryKey('id');
         $this->forge->addForeignKey('tenant_id', 'tenants', 'id', 'NO ACTION', 'CASCADE');
         $this->forge->addUniqueKey(['tenant_id', 'slug']);
+        $this->forge->addUniqueKey(['tenant_id', 'name']);
 
         $this->forge->createTable('categories');
     }

--- a/app/Database/Migrations/2026-03-05-092000_CreateCategoriesTable.php
+++ b/app/Database/Migrations/2026-03-05-092000_CreateCategoriesTable.php
@@ -9,15 +9,19 @@ class CreateCategoriesTable extends Migration
     public function up(): void
     {
         $this->forge->addField([
-            'id'         => ['type' => 'int', 'unsigned' => true, 'auto_increment' => true],
-            'tenant_id'  => ['type' => 'int', 'unsigned' => true, 'null' => false],
-            'name'       => ['type' => 'varchar', 'constraint' => 255, 'null' => false],
-            'created_at' => ['type' => 'datetime', 'null' => true],
-            'updated_at' => ['type' => 'datetime', 'null' => true],
+            'id'          => ['type' => 'int', 'unsigned' => true, 'auto_increment' => true],
+            'tenant_id'   => ['type' => 'int', 'unsigned' => true, 'null' => false],
+            'name'        => ['type' => 'varchar', 'constraint' => 255, 'null' => false],
+            'slug'        => ['type' => 'varchar', 'constraint' => 255, 'null' => false],
+            'description' => ['type' => 'text', 'null' => true],
+            'created_at'  => ['type' => 'datetime', 'null' => true],
+            'updated_at'  => ['type' => 'datetime', 'null' => true],
         ]);
 
         $this->forge->addPrimaryKey('id');
         $this->forge->addForeignKey('tenant_id', 'tenants', 'id', 'NO ACTION', 'CASCADE');
+        $this->forge->addUniqueKey(['tenant_id', 'slug']);
+
         $this->forge->createTable('categories');
     }
 

--- a/app/Entities/CategoryEntity.php
+++ b/app/Entities/CategoryEntity.php
@@ -8,3 +8,4 @@ class CategoryEntity extends Entity
 {
     protected $dates   = ['created_at', 'updated_at'];
 }
+

--- a/app/Entities/UserEntity.php
+++ b/app/Entities/UserEntity.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Entities;
+
+use CodeIgniter\Shield\Entities\User;
+
+
+/**
+ * @property int $tenant_id
+ */
+class UserEntity extends User
+{
+    protected $datamap = [];
+    protected $dates   = ['created_at', 'updated_at', 'deleted_at'];
+    protected $casts   = [];
+}

--- a/app/Models/CategoryModel.php
+++ b/app/Models/CategoryModel.php
@@ -3,11 +3,14 @@
 namespace App\Models;
 
 use App\Entities\CategoryEntity;
+use App\Traits\SlugGeneratorTrait;
 use CodeIgniter\Model;
 use Faker\Generator;
 
 class CategoryModel extends Model
 {
+    use SlugGeneratorTrait;
+
     protected $table = 'categories';
     protected $primaryKey = 'id';
     protected $useAutoIncrement = true;
@@ -15,7 +18,7 @@ class CategoryModel extends Model
     protected $useSoftDeletes = false;
     protected $protectFields = true;
     protected $allowedFields = [
-        'tenant_id', 'name',
+        'tenant_id', 'name', 'slug', 'description'
     ];
 
     protected bool $allowEmptyInserts = false;
@@ -34,6 +37,13 @@ class CategoryModel extends Model
     ];
     protected $skipValidation = false;
     protected $cleanValidationRules = true;
+
+    // Callbacks
+    protected $slugSource = 'name';
+    protected $beforeInsert = ['generateSlug'];
+    protected $beforeUpdate = ['generateSlug'];
+
+
 
     /**
      * fake Category 모델 인스턴스 반환

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -3,11 +3,14 @@
 namespace App\Models;
 
 use App\Entities\PostEntity;
+use App\Traits\SlugGeneratorTrait;
 use CodeIgniter\Model;
 use Faker\Generator;
 
 class PostModel extends Model
 {
+    use SlugGeneratorTrait;
+
     protected $table = 'posts';
     protected $primaryKey = 'id';
     protected $useAutoIncrement = true;
@@ -37,31 +40,7 @@ class PostModel extends Model
 
     // callbacks
     protected $beforeInsert = ['generateSlug'];
-
-
-    /**
-     * Generate slug
-     *
-     * @param array $data
-     * @return array
-     */
-    protected function generateSlug(array $data)
-    {
-        $slug = url_title($data['data']['title'], '-', true);
-
-        $existingSlugCount = $this
-            ->where('slug LIKE', "{$slug}%")
-            ->where('tenant_id', $data['data']['tenant_id'])
-            ->countAllResults();
-
-        if ($existingSlugCount > 0) {
-            $slug .= '-' . ($existingSlugCount);
-        }
-
-        $data['data']['slug'] = $slug;
-
-        return $data;
-    }
+    protected $slugSource = 'title';
 
     /**
      * Filtering by title and content

--- a/app/Traits/SlugGeneratorTrait.php
+++ b/app/Traits/SlugGeneratorTrait.php
@@ -14,16 +14,32 @@ trait SlugGeneratorTrait
             throw new RuntimeException('slugSource property is not defined in the model');
         }
 
+        $id = isset($data['id']) ? (is_array($data['id']) ? $data['id'][0] : $data['id']) : null;
+
         if (isset($data['data'][$this->slugSource])) {
             $slug = mb_url_title($data['data'][$this->slugSource], '-', true);
 
-            $tenantId = isset($data['data']['tenant_id'])
-                ? $data['data']['tenant_id']
-                : $this->find($data['id'])->tenant_id;
+            if (isset($data['data']['tenant_id'])) {
+                $tenantId = $data['data']['tenant_id'];
+            } else {
+                $result = $this->find($id);
+
+                if (!$result) {
+                    throw new RuntimeException('Failed to find the model with the given ID');
+                }
+
+                $tenantId = $result->tenant_id;
+            }
 
             $existingSlugCount = $this
-                ->where('slug LIKE', "{$slug}%")
+                ->groupStart()
+                    ->where('slug', $slug)
+                    ->orLike('slug', $slug . '-', 'after')  // "slug-%" 패턴
+                ->groupEnd()
                 ->where('tenant_id', $tenantId)
+                ->when($id, function ($query) use ($id) {
+                    return $query->where('id !=', $id);
+                })
                 ->countAllResults();
 
             if ($existingSlugCount > 0) {

--- a/app/Traits/SlugGeneratorTrait.php
+++ b/app/Traits/SlugGeneratorTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Traits;
+
+use CodeIgniter\Model;
+use RuntimeException;
+
+/** @mixin Model */
+trait SlugGeneratorTrait
+{
+    protected function generateSlug(array $data): array
+    {
+        if (!property_exists($this, 'slugSource')) {
+            throw new RuntimeException('slugSource property is not defined in the model');
+        }
+
+        if (isset($data['data'][$this->slugSource])) {
+            $slug = mb_url_title($data['data'][$this->slugSource], '-', true);
+
+            $tenantId = isset($data['data']['tenant_id'])
+                ? $data['data']['tenant_id']
+                : $this->find($data['id'])->tenant_id;
+
+            $existingSlugCount = $this
+                ->where('slug LIKE', "{$slug}%")
+                ->where('tenant_id', $tenantId)
+                ->countAllResults();
+
+            if ($existingSlugCount > 0) {
+                $slug .= '-' . ($existingSlugCount + 1);
+            }
+
+            $data['data']['slug'] = $slug;
+        }
+
+        return $data;
+    }
+}


### PR DESCRIPTION
## Summary
- CategoriesController CRUD API 구현 (index/show/create/update/delete/posts) (#10)
- SlugGeneratorTrait 추출: PostModel/CategoryModel 중복 slug 생성 로직 공통화
- categories 마이그레이션에 slug, description 컬럼 + tenant_id+slug 유니크 제약조건 추가
- CategoryModel에 beforeInsert/beforeUpdate 콜백으로 slug 자동 생성
- PostsController insert 에러 처리 개선 (validation/DB 에러 분기)

## 변경 파일
- `app/Traits/SlugGeneratorTrait.php` — 신규 (mb_url_title 기반 slug 생성)
- `app/Controllers/Api/V1/CategoriesController.php` — CRUD 구현
- `app/Models/CategoryModel.php` — slug/description 필드, SlugGeneratorTrait 적용
- `app/Models/PostModel.php` — SlugGeneratorTrait 적용, 기존 generateSlug 제거
- `app/Database/Migrations/2026-03-05-092000_CreateCategoriesTable.php` — slug, description 컬럼 추가
- `app/Controllers/Api/V1/PostsController.php` — insert 에러 분기 개선

## Test plan
- [ ] 카테고리 CRUD API 동작 확인 (index/show/create/update/delete)
- [ ] 카테고리별 포스트 조회 (published만 반환) 확인
- [ ] slug 자동 생성 및 중복 처리 확인
- [ ] name 변경 시 slug 갱신, description만 변경 시 slug 유지 확인
- [ ] PostModel slug 생성이 기존과 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 카테고리 API 전체 구현 — 목록, 상세, 생성, 수정, 삭제 및 카테고리별 발행 포스트 조회 지원
  * 카테고리에 slug 및 description 필드 추가, 슬러그 자동 생성 적용
  * 사용자 엔터티 추가(테넌트 식별자 포함)

* **버그 수정**
  * DB 예외 처리 강화 — DB 오류 시 로깅 후 서버 오류 응답 적용 (카테고리·포스트 생성/수정/삭제)

* **리팩토링**
  * 슬러그 생성 로직 공통화 및 모델 훅으로 통합 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->