### PR TITLE
✨ feat: 태그 관리 + 포스트-태그 N:M 연동 (#10)

### DIFF
--- a/app/Config/AuthGroups.php
+++ b/app/Config/AuthGroups.php
@@ -79,6 +79,7 @@ class AuthGroups extends ShieldAuthGroups
         'categories.manage' => 'Can manage categories',
         'comments.create'   => 'Can create comments',
         'comments.manage'   => 'Can manage and moderate comments',
+        'tags.manage'       => 'Can manage tags',
     ];
 
     /**
@@ -96,6 +97,7 @@ class AuthGroups extends ShieldAuthGroups
             'posts.*',
             'categories.*',
             'comments.*',
+            'tags.*',
         ],
         'admin' => [
             'admin.access',
@@ -105,6 +107,7 @@ class AuthGroups extends ShieldAuthGroups
             'posts.*',
             'categories.manage',
             'comments.manage',
+            'tags.manage',
         ],
         'user' => [
             'posts.view',

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -72,12 +72,13 @@ $routes->group('api/v1', static function ($routes): void {
         $routes->post('pages/(:num)/publish', 'Api\V1\PagesController::publish/$1');
 
         // 카테고리 (#10)
-        $routes->resource('categories', ['controller' => 'Api\V1\CategoriesController']);
+        // posts 서브 라우트를 resource()보다 먼저 등록해야 (:any) 와일드카드에 캡처되지 않음
         $routes->get('categories/(:num)/posts', 'Api\V1\CategoriesController::posts/$1');
+        $routes->resource('categories', ['controller' => 'Api\V1\CategoriesController']);
 
         // 태그 (#10)
-        $routes->resource('tags', ['controller' => 'Api\V1\TagsController']);
         $routes->get('tags/(:num)/posts', 'Api\V1\TagsController::posts/$1');
+        $routes->resource('tags', ['controller' => 'Api\V1\TagsController']);
 
         // 댓글 (#11)
         $routes->resource('comments', ['controller' => 'Api\V1\CommentsController']);

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -137,7 +137,7 @@ class PostsController extends BaseApiController
 
         $createdPost = $this->model->find($postId);
 
-        return $this->responseWithItem($this->transformer->transform($createdPost), 201);
+        return $this->responseWithItem($this->transformer->transformWithTags($createdPost), 201);
     }
 
     /**
@@ -198,7 +198,7 @@ class PostsController extends BaseApiController
 
         $updatedPost = $this->model->find($id);
 
-        return $this->responseWithItem($this->transformer->transform($updatedPost));
+        return $this->responseWithItem($this->transformer->transformWithTags($updatedPost));
     }
 
     /**

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -93,7 +93,7 @@ class PostsController extends BaseApiController
             return $this->failNotFound();
         }
 
-        return $this->responseWithItem($this->transformer->transform($post));
+        return $this->responseWithItem($this->transformer->transformWithTags($post));
     }
 
     /**

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -27,6 +27,12 @@ class PostsController extends BaseApiController
     protected PostTransformer $transformer;
     protected $modelName = PostModel::class;
     protected $format = 'json';
+    protected $rules = [
+        'title'       => 'required|min_length[3]|max_length[255]',
+        'content'     => 'required|min_length[10]',
+        'category_id' => 'required|integer|is_not_unique[categories.id]',
+        'tags'        => 'permit_empty|is_array',
+    ];
 
     public function __construct()
     {
@@ -100,19 +106,13 @@ class PostsController extends BaseApiController
     #[Filter(by: 'apipermission', having: ['posts.create', 'posts.manage'])]
     public function create(): ResponseInterface
     {
-        $rules = [
-            'title'       => 'required|min_length[3]|max_length[255]',
-            'content'     => 'required|min_length[10]',
-            'category_id' => 'required|integer|is_not_unique[categories.id]',
-        ];
-
         $payload = $this->request->getJSON(true);
 
         if (!$payload) {
             return $this->failValidationErrors('Invalid payload');
         }
 
-        if (!$this->validateData($payload, $rules)) {
+        if (!$this->validateData($payload, $this->rules)) {
             return $this->failValidationErrors($this->validator->getErrors());
         }
 
@@ -120,14 +120,23 @@ class PostsController extends BaseApiController
         $payload['state'] = 'draft';
         $payload['tenant_id'] = auth()->user()->tenant_id;
 
+        $tagIds = $this->extractTagIdsFromPayload($payload);
+        unset($payload['tags']);
+
         try {
             $this->model->insert($payload);
+
+            $postId = $this->model->getInsertID();
+
+            if ($tagIds !== null) {
+                $this->model->syncTags($postId, $tagIds, $payload['tenant_id']);
+            }
         } catch (DatabaseException $exception) {
             log_message('error', $exception->getMessage());
             return $this->failServerError('Database error');
         }
 
-        $createdPost = $this->model->find($this->model->getInsertID());
+        $createdPost = $this->model->find($postId);
 
         return $this->responseWithItem($this->transformer->transform($createdPost), 201);
     }
@@ -150,26 +159,29 @@ class PostsController extends BaseApiController
             return $this->failForbidden('You are not authorized to update this post');
         }
 
-        $rules = [
-            'title'       => 'required|min_length[3]|max_length[255]',
-            'content'     => 'required|min_length[10]',
-            'category_id' => 'required|integer|is_not_unique[categories.id]',
-        ];
-
         $payload = $this->request->getJSON(true);
 
-        if (!$this->validateData($payload, $rules)) {
+        if (!$this->validateData($payload, $this->rules)) {
             return $this->failValidationErrors($this->validator->getErrors());
         }
 
-        $allowedPayload = array_intersect_key($payload, $rules);
+        $allowedPayload = array_intersect_key($payload, $this->rules);
 
-        if (!$allowedPayload) {
+        $tagIds = $this->extractTagIdsFromPayload($allowedPayload);
+        unset($allowedPayload['tags']);
+
+        if (!$allowedPayload && $tagIds === null) {
             return $this->failValidationErrors('No valid data provided');
         }
 
         try {
-            $this->model->update($id, $allowedPayload);
+            if ($allowedPayload) {
+                $this->model->update($id, $allowedPayload);
+            }
+
+            if ($tagIds !== null) {
+                $this->model->syncTags($id, $tagIds, $post->tenant_id);
+            }
         } catch (DatabaseException $exception) {
             log_message('error', $exception->getMessage());
             return $this->failServerError('Database error');
@@ -297,5 +309,14 @@ class PostsController extends BaseApiController
         }
 
         return $post->isOwnedBy((int)$user->id) === true || $user->inGroup(UserRole::Superadmin->value) === true;
+    }
+
+    private function extractTagIdsFromPayload(array $payload): ?array
+    {
+        if (!array_key_exists('tags', $payload)) {
+            return null;
+        }
+
+        return array_map('intval', $payload['tags'] ?? []);
     }
 }

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Controllers\Api\V1;
 
 use App\Entities\PostEntity;
@@ -24,12 +25,6 @@ class PostsController extends BaseApiController
     protected PostTransformer $transformer;
     protected $modelName = PostModel::class;
     protected $format = 'json';
-    protected $rules = [
-        'title'       => 'required|min_length[3]|max_length[255]',
-        'content'     => 'required|min_length[10]',
-        'category_id' => 'required|integer|is_not_unique[categories.id]',
-        'tags'        => 'permit_empty|is_array',
-    ];
 
     public function __construct()
     {
@@ -103,13 +98,20 @@ class PostsController extends BaseApiController
     #[Filter(by: 'apipermission', having: ['posts.create', 'posts.manage'])]
     public function create(): ResponseInterface
     {
+        $rules = [
+            'title'       => 'required|min_length[3]|max_length[255]',
+            'content'     => 'required|min_length[10]',
+            'category_id' => 'required|integer|is_not_unique[categories.id]',
+            'tags'        => 'permit_empty|is_array',
+        ];
+
         $payload = $this->request->getJSON(true);
 
         if (!$payload) {
             return $this->failValidationErrors('Invalid payload');
         }
 
-        if (!$this->validateData($payload, $this->rules)) {
+        if (!$this->validateData($payload, $rules)) {
             return $this->failValidationErrors($this->validator->getErrors());
         }
 
@@ -146,6 +148,13 @@ class PostsController extends BaseApiController
     #[Filter(by: 'apipermission', having: ['posts.edit', 'posts.manage'])]
     public function update($id = null): ResponseInterface
     {
+        $rules = [
+            'title'       => 'if_exist|min_length[3]|max_length[255]',
+            'content'     => 'if_exist|min_length[10]',
+            'category_id' => 'if_exist|integer|is_not_unique[categories.id]',
+            'tags'        => 'if_exist|is_array',
+        ];
+
         $post = $this->model->find($id);
 
         if (!$post) {
@@ -158,11 +167,11 @@ class PostsController extends BaseApiController
 
         $payload = $this->request->getJSON(true);
 
-        if (!$this->validateData($payload, $this->rules)) {
+        if (!$this->validateData($payload, $rules)) {
             return $this->failValidationErrors($this->validator->getErrors());
         }
 
-        $allowedPayload = array_intersect_key($payload, $this->rules);
+        $allowedPayload = array_intersect_key($payload, $rules);
 
         $tagIds = $this->extractTagIdsFromPayload($allowedPayload);
         unset($allowedPayload['tags']);

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -1,7 +1,4 @@
 <?php
-
-declare(strict_types=1);
-
 namespace App\Controllers\Api\V1;
 
 use App\Entities\PostEntity;
@@ -173,6 +170,8 @@ class PostsController extends BaseApiController
         if (!$allowedPayload && $tagIds === null) {
             return $this->failValidationErrors('No valid data provided');
         }
+
+        $id = (int)$id;
 
         try {
             if ($allowedPayload) {

--- a/app/Controllers/Api/V1/TagsController.php
+++ b/app/Controllers/Api/V1/TagsController.php
@@ -45,7 +45,7 @@ class TagsController extends BaseApiController
     }
 
     #[Filter(by: 'tokens')]
-    #[Filter(by: 'permission', having: ['tags.manage'])]
+    #[Filter(by: 'apipermission', having: ['tags.manage'])]
     public function create(): ResponseInterface
     {
         $payload = $this->request->getJSON(true);
@@ -79,7 +79,7 @@ class TagsController extends BaseApiController
     }
 
     #[Filter(by: 'tokens')]
-    #[Filter(by: 'permission', having: ['tags.manage'])]
+    #[Filter(by: 'apipermission', having: ['tags.manage'])]
     public function update($id = null): ResponseInterface
     {
         $tenantId = auth()->user()->tenant_id;
@@ -122,7 +122,7 @@ class TagsController extends BaseApiController
     }
 
     #[Filter(by: 'tokens')]
-    #[Filter(by: 'permission', having: ['tags.manage'])]
+    #[Filter(by: 'apipermission', having: ['tags.manage'])]
     public function delete($id = null): ResponseInterface
     {
         $tenantId = auth()->user()->tenant_id;

--- a/app/Controllers/Api/V1/TagsController.php
+++ b/app/Controllers/Api/V1/TagsController.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Controllers\Api\V1;
+
+use App\Models\TagModel;
+use App\Transformers\TagTransformer;
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\HTTP\ResponseInterface;
+use CodeIgniter\Router\Attributes\Filter;
+
+class TagsController extends BaseApiController
+{
+    protected TagTransformer $transformer;
+    protected $modelName = TagModel::class;
+    protected $format = 'json';
+    protected $rules = ['name' => 'required|min_length[3]|max_length[255]'];
+
+    public function __construct()
+    {
+        $this->transformer = new TagTransformer();
+    }
+
+    #[Filter(by: 'tokens')]
+    public function index(): ResponseInterface
+    {
+        $tenantId = auth()->user()->tenant_id;
+        $tags = $this->model->where('tenant_id', $tenantId)->findAll();
+
+        return $this->responseWith($this->transformer->transformMany($tags));
+    }
+
+    #[Filter(by: 'tokens')]
+    public function show($id = null): ResponseInterface
+    {
+        $tenantId = auth()->user()->tenant_id;
+        $tag = $this->model->where('tenant_id', $tenantId)->find($id);
+
+        if (!$tag) {
+            return $this->failNotFound("Tag not found: $id");
+        }
+
+        return $this->respond($this->transformer->transform($tag));
+    }
+
+    #[Filter(by: 'tokens')]
+    #[Filter(by: 'permission', having: ['tags.manage'])]
+    public function create(): ResponseInterface
+    {
+        $payload = $this->request->getJSON(true);
+
+        if (!$payload) {
+            return $this->failValidationErrors('No payload provided');
+        }
+
+        $allowedPayload = array_intersect_key($payload, $this->rules);
+
+        if (!$allowedPayload) {
+            return $this->failValidationErrors('Invalid payload');
+        }
+
+        if (!$this->validateData($allowedPayload, $this->rules)) {
+            return $this->failValidationErrors($this->validator->getErrors());
+        }
+
+        $allowedPayload['tenant_id'] = auth()->user()->tenant_id;
+
+        try {
+            $this->model->insert($allowedPayload);
+        } catch (DatabaseException $exception) {
+            log_message('error', $exception->getMessage());
+            return $this->failServerError('Database error');
+        }
+
+        $createdTag = $this->model->find($this->model->getInsertID());
+
+        return $this->respondCreated($this->transformer->transform($createdTag));
+    }
+
+    #[Filter(by: 'tokens')]
+    #[Filter(by: 'permission', having: ['tags.manage'])]
+    public function update($id = null): ResponseInterface
+    {
+        $tenantId = auth()->user()->tenant_id;
+        $tag = $this->model
+            ->where('tenant_id', $tenantId)
+            ->find($id);
+
+        if (!$tag) {
+            return $this->failNotFound("Tag not found: $id");
+        }
+
+        $payload = $this->request->getJSON(true);
+
+        if (!$payload) {
+            return $this->failValidationErrors('No payload provided');
+        }
+
+        $allowedPayload = array_intersect_key($payload, $this->rules);
+
+        if (!$allowedPayload) {
+            return $this->failValidationErrors('Invalid payload');
+        }
+
+        $updateRules = array_intersect_key($this->rules, $allowedPayload);
+
+        if (!$this->validateData($allowedPayload, $updateRules)) {
+            return $this->failValidationErrors($this->validator->getErrors());
+        }
+
+        try {
+            $this->model->update($id, $allowedPayload);
+        } catch (DatabaseException $exception) {
+            log_message('error', $exception->getMessage());
+            return $this->failServerError('Database error');
+        }
+
+        $updatedTag = $this->model->find($id);
+
+        return $this->responseWithItem($this->transformer->transform($updatedTag));
+    }
+
+    #[Filter(by: 'tokens')]
+    #[Filter(by: 'permission', having: ['tags.manage'])]
+    public function delete($id = null): ResponseInterface
+    {
+        $tenantId = auth()->user()->tenant_id;
+        $tag = $this->model
+            ->where('tenant_id', $tenantId)
+            ->find($id);
+
+        if (!$tag) {
+            return $this->failNotFound("Tag not found: $id");
+        }
+
+        try {
+            $this->model->delete($id);
+        } catch (DatabaseException $exception) {
+            log_message('error', $exception->getMessage());
+            return $this->failServerError('Database error');
+        }
+
+        return $this->respondNoContent();
+    }
+
+    #[Filter(by: 'tokens')]
+    public function posts($id = null): ResponseInterface
+    {
+        // TODO Step 2: post_tags JOIN으로 구현
+        return $this->respond([]);
+    }
+}

--- a/app/Controllers/Api/V1/TagsController.php
+++ b/app/Controllers/Api/V1/TagsController.php
@@ -2,7 +2,9 @@
 
 namespace App\Controllers\Api\V1;
 
+use App\Models\PostModel;
 use App\Models\TagModel;
+use App\Transformers\PostTransformer;
 use App\Transformers\TagTransformer;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\HTTP\ResponseInterface;
@@ -145,7 +147,15 @@ class TagsController extends BaseApiController
     #[Filter(by: 'tokens')]
     public function posts($id = null): ResponseInterface
     {
-        // TODO Step 2: post_tags JOIN으로 구현
-        return $this->respond([]);
+        $tenantId = auth()->user()->tenant_id;
+        $tag = $this->model->where('tenant_id', $tenantId)->find($id);
+
+        if (!$tag) {
+            return $this->failNotFound("Tag not found: $id");
+        }
+
+        $posts = model(PostModel::class)->findByTag($id, $tenantId);
+
+        return $this->responseWith((new PostTransformer())->transformMany($posts));
     }
 }

--- a/app/Controllers/Api/V1/TagsController.php
+++ b/app/Controllers/Api/V1/TagsController.php
@@ -41,7 +41,7 @@ class TagsController extends BaseApiController
             return $this->failNotFound("Tag not found: $id");
         }
 
-        return $this->respond($this->transformer->transform($tag));
+        return $this->responseWithItem($this->transformer->transform($tag));
     }
 
     #[Filter(by: 'tokens')]
@@ -75,7 +75,7 @@ class TagsController extends BaseApiController
 
         $createdTag = $this->model->find($this->model->getInsertID());
 
-        return $this->respondCreated($this->transformer->transform($createdTag));
+        return $this->responseWithItem($this->transformer->transform($createdTag), 201);
     }
 
     #[Filter(by: 'tokens')]

--- a/app/Database/Seeds/CategorySeeder.php
+++ b/app/Database/Seeds/CategorySeeder.php
@@ -2,15 +2,17 @@
 
 namespace App\Database\Seeds;
 
+use App\Models\CategoryModel;
 use CodeIgniter\Database\Seeder;
 
 class CategorySeeder extends Seeder
 {
     public function run()
     {
-        $this->db->table('categories')->insert([
+        $model = new CategoryModel();
+        $model->insert([
             'name'      => 'Test Category',
-            'tenant_id' => 1
+            'tenant_id' => 1,
         ]);
     }
 }

--- a/app/Database/Seeds/CategorySeeder.php
+++ b/app/Database/Seeds/CategorySeeder.php
@@ -9,8 +9,7 @@ class CategorySeeder extends Seeder
 {
     public function run()
     {
-        $model = new CategoryModel();
-        $model->insert([
+        model(CategoryModel::class)->insert([
             'name'      => 'Test Category',
             'tenant_id' => 1,
         ]);

--- a/app/Database/Seeds/UserSeeder.php
+++ b/app/Database/Seeds/UserSeeder.php
@@ -11,17 +11,26 @@ class UserSeeder extends Seeder
     {
         $provider = auth()->getProvider();
 
-        $user = new User([
+        $admin = new User([
             'email'     => 'admin@example.com',
             'username'  => 'admin',
             'password'  => 'password123',
             'tenant_id' => 1,
         ]);
 
+        $provider->save($admin);
+        $admin = $provider->findById($provider->getInsertID());
+        $admin->addGroup('admin');
+
+        $user = new User([
+            'email' => 'user@example.com',
+            'username' => 'user',
+            'password' => 'password123',
+            'tenant_id' => 1,
+        ]);
+
         $provider->save($user);
-
         $user = $provider->findById($provider->getInsertID());
-
-        $user->addGroup('admin');
+        $user->addGroup('user');
     }
 }

--- a/app/Entities/TagEntity.php
+++ b/app/Entities/TagEntity.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Entities;
+
+use CodeIgniter\Entity\Entity;
+
+class TagEntity extends Entity
+{
+    protected $datamap = [];
+    protected $dates   = ['created_at', 'updated_at'];
+    protected $casts   = [];
+}

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -73,4 +73,56 @@ class PostModel extends Model
             'tenant_id'   => 1,
         ];
     }
+
+    public function syncTags(int $postId, array $tagIds, int $tenantId): void
+    {
+        if (empty($tagIds)) {
+            $this->deleteOldTags($postId, $tenantId);
+            return;
+        }
+
+        $this->db->transStart();
+
+        // tenant validation
+        $results = $this->db->table('tags')
+            ->select('id')
+            ->whereIn('id', $tagIds)
+            ->where('tenant_id', $tenantId)
+            ->get()
+            ->getResultArray();
+
+        $validTagIds = array_column($results, 'id');
+
+        // delete old tags
+        $this->deleteOldTags($postId, $tenantId);
+
+        // insert new tags
+        if (!empty($validTagIds)) {
+            $rows = array_map(
+                fn($tagId) => ['post_id' => $postId, 'tag_id' => $tagId, 'tenant_id' => $tenantId],
+                $validTagIds
+            );
+            $this->db->table('post_tags')
+                ->insertBatch($rows);
+        }
+
+        $this->db->transComplete();
+    }
+
+    private function deleteOldTags(int $postId, int $tenantId): void
+    {
+        $this->db->table('post_tags')
+            ->where('post_id', $postId)
+            ->where('tenant_id', $tenantId)
+            ->delete();
+    }
+
+    public function findByTag(int $tagId, int $tenantId): array
+    {
+        return $this->join('post_tags', 'post_tags.post_id = posts.id')
+            ->where('post_tags.tag_id', $tagId)
+            ->where('posts.tenant_id', $tenantId)
+            ->where('posts.state', 'published')
+            ->findAll();
+    }
 }

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -119,7 +119,8 @@ class PostModel extends Model
 
     public function findByTag(int $tagId, int $tenantId): array
     {
-        return $this->join('post_tags', 'post_tags.post_id = posts.id')
+        return $this->select('posts.*')
+            ->join('post_tags', 'post_tags.post_id = posts.id')
             ->where('post_tags.tag_id', $tagId)
             ->where('posts.tenant_id', $tenantId)
             ->where('posts.state', 'published')

--- a/app/Models/TagModel.php
+++ b/app/Models/TagModel.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+use App\Entities\TagEntity;
+
+class TagModel extends Model
+{
+    protected $table            = 'tags';
+    protected $primaryKey       = 'id';
+    protected $useAutoIncrement = true;
+    protected $returnType       = TagEntity::class;
+    protected $useSoftDeletes   = false;
+    protected $protectFields    = true;
+    protected $allowedFields    = ['tenant_id', 'name'];
+
+    protected bool $allowEmptyInserts = false;
+    protected bool $updateOnlyChanged = true;
+
+    // Dates
+    protected $useTimestamps = true;
+    protected $dateFormat    = 'datetime';
+    protected $createdField  = 'created_at';
+    protected $updatedField  = 'updated_at';
+
+    // Validation
+    protected $validationRules      = [
+        'tenant_id' => 'required|integer',
+        'name'      => 'required|min_length[3]|max_length[255]',
+    ];
+    protected $validationMessages   = [];
+    protected $skipValidation       = false;
+    protected $cleanValidationRules = true;
+}

--- a/app/Models/TagModel.php
+++ b/app/Models/TagModel.php
@@ -36,7 +36,8 @@ class TagModel extends Model
 
     public function findByPost(int $postId, int $tenantId): array
     {
-        return $this->join('post_tags', 'post_tags.tag_id = tags.id')
+        return $this->select('tags.*')
+            ->join('post_tags', 'post_tags.tag_id = tags.id')
             ->where('post_tags.post_id', $postId)
             ->where('tags.tenant_id', $tenantId)
             ->findAll();

--- a/app/Models/TagModel.php
+++ b/app/Models/TagModel.php
@@ -2,35 +2,36 @@
 
 namespace App\Models;
 
-use CodeIgniter\Model;
 use App\Entities\TagEntity;
+use CodeIgniter\Model;
+use Faker\Generator;
 
 class TagModel extends Model
 {
-    protected $table            = 'tags';
-    protected $primaryKey       = 'id';
+    protected $table = 'tags';
+    protected $primaryKey = 'id';
     protected $useAutoIncrement = true;
-    protected $returnType       = TagEntity::class;
-    protected $useSoftDeletes   = false;
-    protected $protectFields    = true;
-    protected $allowedFields    = ['tenant_id', 'name'];
+    protected $returnType = TagEntity::class;
+    protected $useSoftDeletes = false;
+    protected $protectFields = true;
+    protected $allowedFields = ['tenant_id', 'name'];
 
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;
 
     // Dates
     protected $useTimestamps = true;
-    protected $dateFormat    = 'datetime';
-    protected $createdField  = 'created_at';
-    protected $updatedField  = 'updated_at';
+    protected $dateFormat = 'datetime';
+    protected $createdField = 'created_at';
+    protected $updatedField = 'updated_at';
 
     // Validation
-    protected $validationRules      = [
+    protected $validationRules = [
         'tenant_id' => 'required|integer',
         'name'      => 'required|min_length[3]|max_length[255]',
     ];
-    protected $validationMessages   = [];
-    protected $skipValidation       = false;
+    protected $validationMessages = [];
+    protected $skipValidation = false;
     protected $cleanValidationRules = true;
 
     public function findByPost(int $postId, int $tenantId): array
@@ -39,5 +40,13 @@ class TagModel extends Model
             ->where('post_tags.post_id', $postId)
             ->where('tags.tenant_id', $tenantId)
             ->findAll();
+    }
+
+    public function fake(Generator &$faker): array
+    {
+        return [
+            'tenant_id' => 1,
+            'name'      => $faker->unique()->words(2, true),
+        ];
     }
 }

--- a/app/Models/TagModel.php
+++ b/app/Models/TagModel.php
@@ -32,4 +32,12 @@ class TagModel extends Model
     protected $validationMessages   = [];
     protected $skipValidation       = false;
     protected $cleanValidationRules = true;
+
+    public function findByPost(int $postId, int $tenantId): array
+    {
+        return $this->join('post_tags', 'post_tags.tag_id = tags.id')
+            ->where('post_tags.post_id', $postId)
+            ->where('tags.tenant_id', $tenantId)
+            ->findAll();
+    }
 }

--- a/app/Transformers/PostTransformer.php
+++ b/app/Transformers/PostTransformer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Transformers;
 
+use App\Models\TagModel;
 use CodeIgniter\API\BaseTransformer;
 
 class PostTransformer extends BaseTransformer
@@ -57,8 +58,24 @@ class PostTransformer extends BaseTransformer
 
     protected function includeTags(): array
     {
-        // DB 구현 후 채워질 자리
-        return [];
+        $postId = $this->resource->id;
+        $tenantId = $this->resource->tenant_id;
+
+        $tags = model(TagModel::class)->findByPost($postId, $tenantId);
+
+        return (new TagTransformer())->transformMany($tags);
+    }
+
+    public function transformWithTags(array|object $resource): array
+    {
+        $data = $this->transform($resource);
+
+        // 이미 포함되어 있으면 중복 호출 방지
+        if (!isset($data['tags'])) {
+            $data['tags'] = $this->includeTags();
+        }
+
+        return $data;
     }
 
     protected function includeAuthor(): array

--- a/app/Transformers/PostTransformer.php
+++ b/app/Transformers/PostTransformer.php
@@ -56,10 +56,12 @@ class PostTransformer extends BaseTransformer
         return [];
     }
 
-    protected function includeTags(): array
+    protected function includeTags(array|object|null $resource = null): array
     {
-        $postId = $this->resource->id;
-        $tenantId = $this->resource->tenant_id;
+        $resource = $resource ?? $this->resource;
+
+        $postId = is_array($resource) ? $resource['id'] : $resource->id;
+        $tenantId = is_array($resource) ? $resource['tenant_id'] : $resource->tenant_id;
 
         $tags = model(TagModel::class)->findByPost($postId, $tenantId);
 
@@ -72,7 +74,7 @@ class PostTransformer extends BaseTransformer
 
         // 이미 포함되어 있으면 중복 호출 방지
         if (!isset($data['tags'])) {
-            $data['tags'] = $this->includeTags();
+            $data['tags'] = $this->includeTags($resource);
         }
 
         return $data;

--- a/app/Transformers/TagTransformer.php
+++ b/app/Transformers/TagTransformer.php
@@ -13,7 +13,6 @@ class TagTransformer extends BaseTransformer
         return [
             'id'         => $resource['id'],
             'name'       => $resource['name'],
-            'slug'       => $resource['slug'],
             'created_at' => $resource['created_at'],
             'updated_at' => $resource['updated_at'],
         ];
@@ -21,6 +20,6 @@ class TagTransformer extends BaseTransformer
 
     protected function getAllowedFields(): ?array
     {
-        return ['id', 'name', 'slug', 'created_at', 'updated_at'];
+        return ['id', 'name', 'created_at', 'updated_at'];
     }
 }

--- a/public/docs/openapi.yaml
+++ b/public/docs/openapi.yaml
@@ -823,9 +823,14 @@ paths:
                   - type: object
                     properties:
                       data:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Post'
+                        type: object
+                        properties:
+                          items:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Post'
+                          pagination:
+                            $ref: '#/components/schemas/Pagination'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':

--- a/public/docs/openapi.yaml
+++ b/public/docs/openapi.yaml
@@ -801,6 +801,36 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /tags/{id}/posts:
+    get:
+      tags:
+        - Tags
+      summary: 태그별 포스트 조회
+      description: 특정 태그가 달린 published 포스트 목록을 조회합니다.
+      operationId: getTagPosts
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/IdParam'
+      responses:
+        '200':
+          description: 포스트 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Post'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   # Comments Endpoints
   /comments:
     get:
@@ -1921,9 +1951,6 @@ components:
         name:
           type: string
           example: PHP
-        slug:
-          type: string
-          example: php
         created_at:
           type: string
           format: date-time
@@ -1937,14 +1964,12 @@ components:
       type: object
       required:
         - name
-        - slug
       properties:
         name:
           type: string
+          minLength: 3
+          maxLength: 255
           example: PHP
-        slug:
-          type: string
-          example: php
 
     # Comment Schemas
     Comment:

--- a/tests/api/CategoriesApiTest.php
+++ b/tests/api/CategoriesApiTest.php
@@ -71,7 +71,7 @@ class CategoriesApiTest extends CIUnitTestCase
             ->post('/api/v1/categories', $categoryData);
 
         $result->assertStatus(201);
-        $json = $result->getJSON();
+        $json = json_decode($result->getJSON());
         $this->assertEquals($categoryData['name'], $json->data->name);
     }
 
@@ -101,7 +101,7 @@ class CategoriesApiTest extends CIUnitTestCase
         $result = $this->get('/api/v1/categories/1');
 
         $result->assertStatus(200);
-        $json = $result->getJSON();
+        $json = json_decode($result->getJSON());
         $this->assertObjectHasProperty('data', $json);
         $this->assertEquals(1, $json->data->id);
     }
@@ -126,7 +126,7 @@ class CategoriesApiTest extends CIUnitTestCase
             ->put('/api/v1/categories/1', $updateData);
 
         $result->assertStatus(200);
-        $json = $result->getJSON();
+        $json = json_decode($result->getJSON());
         $this->assertEquals($updateData['name'], $json->data->name);
     }
 
@@ -159,7 +159,7 @@ class CategoriesApiTest extends CIUnitTestCase
         $result = $this->get('/api/v1/categories/1/posts');
 
         $result->assertStatus(200);
-        $json = $result->getJSON();
+        $json = json_decode($result->getJSON());
         $this->assertObjectHasProperty('data', $json);
         $this->assertIsArray($json->data);
     }

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -7,6 +7,7 @@ use App\Enums\PostState;
 use App\Enums\UserRole;
 use App\Models\CategoryModel;
 use App\Models\PostModel;
+use App\Models\TagModel;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
@@ -348,6 +349,62 @@ class PostsApiTest extends CIUnitTestCase
             'status' => 'success',
             'code'   => 201
         ]);
+    }
+
+    /**
+     * @test
+     * POST /api/v1/posts
+     * tags 필드와 함께 포스트 생성 시 post_tags 테이블에 연결 생성 확인
+     */
+    public function test_create_post_with_tags(): void
+    {
+        $this->loginAsAdmin();
+
+        $tags = $this->createFakeTags(2);
+
+        $payload = $this->testPost;
+        $payload['tags'] = [$tags[0]->id, $tags[1]->id];
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->withBodyFormat('json')
+            ->post('/api/v1/posts', $payload);
+
+        $result->assertStatus(201);
+
+        $json = json_decode($result->getJSON());
+        $postId = $json->data->id;
+
+        $this->seeNumRecords(2, 'post_tags', ['post_id' => $postId]);
+        $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[0]->id]);
+        $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[1]->id]);
+    }
+
+    /**
+     * @test
+     * GET /api/v1/posts/{id}
+     * Post 상세 조회 시 tags가 항상 응답에 포함되어야 한다(Transformer include 강제)
+     */
+    public function test_show_post_includes_tags_always(): void
+    {
+        $this->loginAsAdmin();
+
+        $tags = $this->createFakeTags(2);
+
+        $fabricator = new Fabricator(PostModel::class);
+        $post = $fabricator->setOverrides(['state' => PostState::Published])->create();
+
+        $this->db->table('post_tags')->insertBatch([
+            ['post_id' => $post->id, 'tag_id' => $tags[0]->id, 'tenant_id' => 1],
+            ['post_id' => $post->id, 'tag_id' => $tags[1]->id, 'tenant_id' => 1],
+        ]);
+
+        $result = $this->get("/api/v1/posts/{$post->id}");
+
+        $result->assertStatus(200);
+
+        $json = json_decode($result->getJSON());
+        $this->assertObjectHasProperty('tags', $json->data);
+        $this->assertCount(2, $json->data->tags);
     }
 
     /** @test
@@ -726,9 +783,6 @@ class PostsApiTest extends CIUnitTestCase
         ];
     }
 
-    /**
-     * @return array
-     */
     public function createDifferentOwnerPosts(UserRole $role = UserRole::Admin): array
     {
         $provider = auth()->getProvider();
@@ -764,5 +818,12 @@ class PostsApiTest extends CIUnitTestCase
         ])->create();
 
         return [$loginUser, $post];
+    }
+
+    protected function createFakeTags(int $count): array
+    {
+        $fabricator = new Fabricator(TagModel::class);
+
+        return $fabricator->setOverrides(['tenant_id' => 1])->create($count);
     }
 }

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -54,6 +54,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts
+     *
      * 포스트 목록 조회 테스트 (인증 불필요)
      */
     public function test_get_posts_list_without_auth(): void
@@ -76,6 +77,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts?page=1&per_page=10
+     *
      * 페이지네이션 테스트
      */
     public function test_get_posts_with_pagination(): void
@@ -94,6 +96,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts?search=검색키워드
+     *
      * 키워드 필터링 테스트
      */
     public function test_get_posts_with_search_keyword_filtering(): void
@@ -127,6 +130,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts?search=검색키워드
+     *
      * 검색 결과가 없는 경우의 키워드 필터링 테스트
      */
     public function test_get_posts_with_search_keyword_filtering_no_results(): void
@@ -149,6 +153,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts
+     *
      * 게시글 목록 조회시 'draft' 상태의 게시글은 조회되지 않아야 한다.
      */
     public function test_get_posts_list_excludes_draft_posts(): void
@@ -171,6 +176,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts
+     *
      * 게시글 목록 조회시 'published' 상태의 게시글만 조회 되어야 함.
      */
     public function test_get_posts_list_includes_published_posts(): void
@@ -193,6 +199,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts
+     *
      * 검색어 매칭되는 draft 상태의 게시물은 검색에서 제외 되어야 함.
      */
     public function test_get_posts_list_excludes_draft_posts_from_search(): void
@@ -227,6 +234,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts?category_id={category_id}
+     *
      * 카테고리 ID로 게시글 조회 테스트
      */
     public function test_get_posts_by_category_id(): void
@@ -265,6 +273,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts?category_id={category_id}
+     *
      * 존재하지 않는 카테고리 ID로 게시글 목록 조회 테스트
      */
     public function test_get_posts_by_not_exist_category_id(): void
@@ -283,6 +292,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts?category_id={category_id}
+     *
      * 잘못된 형식의 카테고리 ID로 게시글 목록 조회 테스트
      */
     public function test_get_posts_by_invalid_category_id(): void
@@ -295,6 +305,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts?category_id={category_id}&search={keyword}
+     *
      * 카테고리 ID와 검색어로 게시글 목록 조회 테스트
      */
     public function test_get_posts_by_category_id_and_keyword(): void
@@ -334,6 +345,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * POST /api/v1/posts
+     *
      * 포스트 생성 테스트 (admin 권한 필요)
      */
     public function test_create_post_with_admin_role(): void
@@ -354,6 +366,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * POST /api/v1/posts
+     *
      * tags 필드와 함께 포스트 생성 시 post_tags 테이블에 연결 생성 확인
      */
     public function test_create_post_with_tags(): void
@@ -382,6 +395,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts/{id}
+     *
      * Post 상세 조회 시 tags가 항상 응답에 포함되어야 한다(Transformer include 강제)
      */
     public function test_show_post_includes_tags_always(): void
@@ -409,6 +423,7 @@ class PostsApiTest extends CIUnitTestCase
 
     /** @test
      * PUT /api/v1/posts/{id}
+     *
      * 포스트 작성자일 경우 업데이트 허용 테스트
      */
     public function test_update_post_with_owner(): void
@@ -445,6 +460,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * PUT /api/v1/posts/{id}
+     *
      * 다른 사용자의 포스트 업데이트 실패 테스트
      */
     public function test_update_with_other_owner_post(): void
@@ -467,6 +483,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * POST /api/v1/posts
+     *
      * 인증 없이 포스트 생성 실패 테스트
      */
     public function test_create_post_fails_without_auth(): void
@@ -480,6 +497,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * POST /api/v1/posts
+     *
      * 유효성 검증 실패 테스트
      */
     public function test_create_post_validates_required_fields(): void
@@ -504,6 +522,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts/{id}
+     *
      * 포스트 상세 조회 테스트
      */
     public function test_get_post_by_id(): void
@@ -525,6 +544,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts/{id}
+     *
      * 존재하지 않는 포스트 조회 실패 테스트
      */
     public function test_get_nonexistent_post_returns_404(): void
@@ -540,6 +560,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * PUT /api/v1/posts/{id}
+     *
      * 포스트 수정 테스트
      */
     public function test_update_post(): void
@@ -568,6 +589,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * PUT /api/v1/posts/{id}
+     *
      * SuperAdmin 권한으로 다른 작성자의 게시글 수정
      */
     public function test_update_post_with_super_admin()
@@ -592,6 +614,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * DELETE /api/v1/posts/{id}
+     *
      * 포스트 삭제 테스트 (Admin 권한 필요)
      */
     public function test_delete_post_with_admin_role(): void
@@ -613,6 +636,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * DELETE /api/v1/posts/{id}
+     *
      * 다른 작성자의 포스트 삭제 테스트 (권한 없음)
      */
     public function test_delete_post_with_other_owner(): void
@@ -630,6 +654,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * POST /api/v1/posts/{id}/publish
+     *
      * 포스트 발행 테스트
      */
     public function test_publish_post(): void
@@ -652,6 +677,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * POST /api/v1/posts/{id}/publish
+     *
      * 다른 작성자의 게시글 발행 테스트
      */
     public function test_publish_post_with_other_owner(): void
@@ -669,6 +695,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * POST /api/v1/posts/{id}/unpublish
+     *
      * 포스트 발행 취소 테스트
      */
     public function test_unpublish_post(): void
@@ -695,6 +722,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * POST /api/v1/posts/{id}/unpublish
+     *
      * 다른 작성작의 게시글 발행 취소 테스트
      */
     public function test_unpublish_post_with_other_owner(): void
@@ -710,7 +738,70 @@ class PostsApiTest extends CIUnitTestCase
 
     /**
      * @test
+     * PUT /api/v1/posts/{id}
+     *
+     * 기존 태그를 새로운 태그로 교체 테스트
+     */
+    public function test_update_post_replaces_tags(): void
+    {
+        $postId = $this->createTestPost();
+        $tags = $this->createFakeTags(4);
+
+        $this->attachTags($postId, [$tags[0]->id, $tags[1]->id]);
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->put("/api/v1/posts/{$postId}", ['tags' => [$tags[2]->id, $tags[3]->id]]);
+
+        $result->assertStatus(200);
+        $this->seeNumRecords(2, 'post_tags', ['post_id' => $postId]);
+        $this->dontSeeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[0]->id]);
+        $this->dontSeeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[1]->id]);
+        $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[2]->id]);
+        $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[3]->id]);
+    }
+
+    /**
+     * @test
+     * PUT /api/v1/posts/{id}
+     *
+     * tags 키가 없을 경우 기존 태그를 유지하는지 테스트
+     */
+    public function test_update_post_without_tags_key_keeps_tags(): void
+    {
+        $postId = $this->createTestPost();
+        $tags = $this->createFakeTags(2);
+
+        $this->attachTags($postId, [$tags[0]->id, $tags[1]->id]);
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->put("/api/v1/posts/{$postId}", ['title' => '태그없는 포스트']);
+
+        $result->assertStatus(200);
+        $this->seeNumRecords(2, 'post_tags', ['post_id' => $postId]);
+        $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[0]->id]);
+        $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[1]->id]);
+    }
+
+    public function test_update_post_with_empty_tags_removes_all(): void
+    {
+        $postId = $this->createTestPost();
+        $tags = $this->createFakeTags(4);
+
+        $this->attachTags($postId, [$tags[0]->id, $tags[1]->id]);
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->put("/api/v1/posts/{$postId}", ['tags' => []]);
+
+        $result->assertStatus(200);
+        $this->seeNumRecords(0, 'post_tags', ['post_id' => $postId]);
+        $this->dontSeeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[0]->id]);
+        $this->dontSeeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[1]->id]);
+    }
+
+    /**
+     * @test
      * POST /api/v1/posts/{id}/unpublish
+     *
      * draft 상태인 포스트의 발행 취소시 409 오류 리턴 테스트
      */
     public function test_draft_post_unpublish_post(): void
@@ -727,13 +818,13 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * @test
      * GET /api/v1/posts/{id}/comments
+     *
      * 포스트 댓글 목록 조회 테스트 (미구현)
      */
     public function test_get_post_comments(): void
     {
         $this->markTestIncomplete('POST comments endpoint not fully implemented yet');
     }
-
 
     // Helper Methods
 
@@ -826,4 +917,12 @@ class PostsApiTest extends CIUnitTestCase
 
         return $fabricator->setOverrides(['tenant_id' => 1])->create($count);
     }
+
+    protected function attachTags($postId, $tags)
+    {
+        $this->db->table('post_tags')->insertBatch(
+            array_map(fn ($tagId) => ['post_id' => $postId, 'tag_id' => $tagId, 'tenant_id' => 1], $tags)
+        );
+    }
+
 }

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -52,7 +52,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts
      *
      * 포스트 목록 조회 테스트 (인증 불필요)
@@ -75,7 +74,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts?page=1&per_page=10
      *
      * 페이지네이션 테스트
@@ -94,7 +92,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts?search=검색키워드
      *
      * 키워드 필터링 테스트
@@ -128,7 +125,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts?search=검색키워드
      *
      * 검색 결과가 없는 경우의 키워드 필터링 테스트
@@ -151,7 +147,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts
      *
      * 게시글 목록 조회시 'draft' 상태의 게시글은 조회되지 않아야 한다.
@@ -174,7 +169,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts
      *
      * 게시글 목록 조회시 'published' 상태의 게시글만 조회 되어야 함.
@@ -197,7 +191,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts
      *
      * 검색어 매칭되는 draft 상태의 게시물은 검색에서 제외 되어야 함.
@@ -232,7 +225,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts?category_id={category_id}
      *
      * 카테고리 ID로 게시글 조회 테스트
@@ -271,7 +263,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts?category_id={category_id}
      *
      * 존재하지 않는 카테고리 ID로 게시글 목록 조회 테스트
@@ -290,7 +281,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts?category_id={category_id}
      *
      * 잘못된 형식의 카테고리 ID로 게시글 목록 조회 테스트
@@ -303,7 +293,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts?category_id={category_id}&search={keyword}
      *
      * 카테고리 ID와 검색어로 게시글 목록 조회 테스트
@@ -343,7 +332,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * POST /api/v1/posts
      *
      * 포스트 생성 테스트 (admin 권한 필요)
@@ -364,7 +352,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * POST /api/v1/posts
      *
      * tags 필드와 함께 포스트 생성 시 post_tags 테이블에 연결 생성 확인
@@ -393,7 +380,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts/{id}
      *
      * Post 상세 조회 시 tags가 항상 응답에 포함되어야 한다(Transformer include 강제)
@@ -421,7 +407,7 @@ class PostsApiTest extends CIUnitTestCase
         $this->assertCount(2, $json->data->tags);
     }
 
-    /** @test
+    /**
      * PUT /api/v1/posts/{id}
      *
      * 포스트 작성자일 경우 업데이트 허용 테스트
@@ -458,7 +444,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * PUT /api/v1/posts/{id}
      *
      * 다른 사용자의 포스트 업데이트 실패 테스트
@@ -481,7 +466,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * POST /api/v1/posts
      *
      * 인증 없이 포스트 생성 실패 테스트
@@ -495,7 +479,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * POST /api/v1/posts
      *
      * 유효성 검증 실패 테스트
@@ -520,7 +503,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts/{id}
      *
      * 포스트 상세 조회 테스트
@@ -542,7 +524,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts/{id}
      *
      * 존재하지 않는 포스트 조회 실패 테스트
@@ -558,7 +539,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * PUT /api/v1/posts/{id}
      *
      * 포스트 수정 테스트
@@ -587,7 +567,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * PUT /api/v1/posts/{id}
      *
      * SuperAdmin 권한으로 다른 작성자의 게시글 수정
@@ -597,8 +576,8 @@ class PostsApiTest extends CIUnitTestCase
         list($loginUser, $post) = $this->createDifferentOwnerPosts(UserRole::Superadmin);
 
         $updateData = [
-            'title'   => '수정된 포스트 제목',
-            'content' => '수정된 내용입니다. 확인해 보세요.',
+            'title'       => '수정된 포스트 제목',
+            'content'     => '수정된 내용입니다. 확인해 보세요.',
             'category_id' => $post->category_id,
         ];
 
@@ -612,7 +591,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * DELETE /api/v1/posts/{id}
      *
      * 포스트 삭제 테스트 (Admin 권한 필요)
@@ -634,7 +612,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * DELETE /api/v1/posts/{id}
      *
      * 다른 작성자의 포스트 삭제 테스트 (권한 없음)
@@ -652,7 +629,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * POST /api/v1/posts/{id}/publish
      *
      * 포스트 발행 테스트
@@ -675,7 +651,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * POST /api/v1/posts/{id}/publish
      *
      * 다른 작성자의 게시글 발행 테스트
@@ -693,7 +668,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * POST /api/v1/posts/{id}/unpublish
      *
      * 포스트 발행 취소 테스트
@@ -720,7 +694,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * POST /api/v1/posts/{id}/unpublish
      *
      * 다른 작성작의 게시글 발행 취소 테스트
@@ -737,7 +710,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * PUT /api/v1/posts/{id}
      *
      * 기존 태그를 새로운 태그로 교체 테스트
@@ -761,7 +733,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * PUT /api/v1/posts/{id}
      *
      * tags 키가 없을 경우 기존 태그를 유지하는지 테스트
@@ -782,6 +753,11 @@ class PostsApiTest extends CIUnitTestCase
         $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[1]->id]);
     }
 
+    /**
+     * PUT /api/v1/posts/{id}
+     *
+     * post 수정 시 태그가 비어있을 경우 기존 태그를 모두 삭제한다.
+     */
     public function test_update_post_with_empty_tags_removes_all(): void
     {
         $postId = $this->createTestPost();
@@ -799,7 +775,37 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
+     * PUT /api/v1/posts/{id}
+     *
+     * post 수정 시 title, tags를 모두 업데이트한다.
+     */
+    public function test_update_post_with_title_and_tags_updates_both(): void
+    {
+        $postId = $this->createTestPost();
+        $tags = $this->createFakeTags(4);
+
+        $this->attachTags($postId, [$tags[0]->id, $tags[1]->id]);
+
+        $updateTitle = 'updated title';
+        $result = $this->withHeaders($this->getHeaders())
+            ->put("/api/v1/posts/{$postId}", [
+                'title' => $updateTitle,
+                'tags'  => [$tags[2]->id, $tags[3]->id]
+            ]);
+
+        $result->assertStatus(200);
+
+        $updatedPost = json_decode($result->getJSON());
+        $this->assertEquals($updateTitle, $updatedPost->data->title);
+
+        $this->seeNumRecords(2, 'post_tags', ['post_id' => $postId]);
+        $this->dontSeeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[0]->id]);
+        $this->dontSeeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[1]->id]);
+        $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[2]->id]);
+        $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[3]->id]);
+    }
+
+    /**
      * POST /api/v1/posts/{id}/unpublish
      *
      * draft 상태인 포스트의 발행 취소시 409 오류 리턴 테스트
@@ -816,7 +822,6 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
-     * @test
      * GET /api/v1/posts/{id}/comments
      *
      * 포스트 댓글 목록 조회 테스트 (미구현)
@@ -921,7 +926,7 @@ class PostsApiTest extends CIUnitTestCase
     protected function attachTags($postId, $tags)
     {
         $this->db->table('post_tags')->insertBatch(
-            array_map(fn ($tagId) => ['post_id' => $postId, 'tag_id' => $tagId, 'tenant_id' => 1], $tags)
+            array_map(fn($tagId) => ['post_id' => $postId, 'tag_id' => $tagId, 'tenant_id' => 1], $tags)
         );
     }
 

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -47,7 +47,6 @@ class PostsApiTest extends CIUnitTestCase
             'excerpt'     => '포스트 요약',
             'status'      => 'draft',
             'category_id' => 1,
-            'tags'        => [1, 2, 3]
         ];
     }
 

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -718,7 +718,6 @@ class PostsApiTest extends CIUnitTestCase
     {
         $postId = $this->createTestPost();
         $tags = $this->createFakeTags(4);
-
         $this->attachTags($postId, [$tags[0]->id, $tags[1]->id]);
 
         $result = $this->withHeaders($this->getHeaders())
@@ -741,7 +740,6 @@ class PostsApiTest extends CIUnitTestCase
     {
         $postId = $this->createTestPost();
         $tags = $this->createFakeTags(2);
-
         $this->attachTags($postId, [$tags[0]->id, $tags[1]->id]);
 
         $result = $this->withHeaders($this->getHeaders())
@@ -762,7 +760,6 @@ class PostsApiTest extends CIUnitTestCase
     {
         $postId = $this->createTestPost();
         $tags = $this->createFakeTags(4);
-
         $this->attachTags($postId, [$tags[0]->id, $tags[1]->id]);
 
         $result = $this->withHeaders($this->getHeaders())
@@ -783,7 +780,6 @@ class PostsApiTest extends CIUnitTestCase
     {
         $postId = $this->createTestPost();
         $tags = $this->createFakeTags(4);
-
         $this->attachTags($postId, [$tags[0]->id, $tags[1]->id]);
 
         $updateTitle = 'updated title';
@@ -803,6 +799,31 @@ class PostsApiTest extends CIUnitTestCase
         $this->dontSeeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[1]->id]);
         $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[2]->id]);
         $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $tags[3]->id]);
+    }
+
+    /**
+     * PUT /api/v1/posts/{id}
+     *
+     * 다른 사용자의 포스트 태그수정 시 403(forbidden) 오류 리턴 테스트
+     */
+    public function test_update_post_with_tags_by_non_owner_returns_forbidden(): void
+    {
+        list($loginUser, $post) = $this->createDifferentOwnerPosts();
+        $tags = $this->createFakeTags(4);
+        $this->attachTags($post->id, [$tags[0]->id, $tags[1]->id]);
+
+        $result = $this->withHeaders($this->getHeaders($loginUser))
+            ->put("/api/v1/posts/{$post->id}", [
+                'title' => 'Updated Title',
+                'tags' => [$tags[2]->id, $tags[3]->id],
+            ]);
+
+        $result->assertStatus(403);
+        $this->seeNumRecords(2, 'post_tags', ['post_id' => $post->id]);
+        $this->seeInDatabase('post_tags', ['post_id' => $post->id, 'tag_id' => $tags[0]->id]);
+        $this->seeInDatabase('post_tags', ['post_id' => $post->id, 'tag_id' => $tags[1]->id]);
+        $this->dontSeeInDatabase('post_tags', ['post_id' => $post->id, 'tag_id' => $tags[2]->id]);
+        $this->dontSeeInDatabase('post_tags', ['post_id' => $post->id, 'tag_id' => $tags[3]->id]);
     }
 
     /**

--- a/tests/api/TagsApiTest.php
+++ b/tests/api/TagsApiTest.php
@@ -61,7 +61,7 @@ class TagsApiTest extends CIUnitTestCase
 
         $result->assertStatus(200);
         $json = json_decode($result->getJSON());
-        $this->assertEquals($tagId, $json->id);
+        $this->assertEquals($tagId, $json->data->id);
     }
 
     /**
@@ -83,7 +83,7 @@ class TagsApiTest extends CIUnitTestCase
 
         $result->assertStatus(201);
         $json = json_decode($result->getJSON());
-        $this->assertEquals($tagData['name'], $json->name);
+        $this->assertEquals($tagData['name'], $json->data->name);
     }
 
     /**
@@ -264,9 +264,9 @@ class TagsApiTest extends CIUnitTestCase
             ->post('/api/v1/tags', $payload);
 
         $json = json_decode($result->getJSON());
-        $this->assertNotNull($json->id ?? null, 'createTestTag failed: ' . $result->getJSON());
+        $this->assertNotNull($json->data->id ?? null, 'createTestTag failed: ' . $result->getJSON());
 
-        return (int)$json->id;
+        return (int)$json->data->id;
     }
 
     protected function loginAsAdmin(): void

--- a/tests/api/TagsApiTest.php
+++ b/tests/api/TagsApiTest.php
@@ -14,7 +14,8 @@ class TagsApiTest extends CIUnitTestCase
     use FeatureTestTrait;
     use DatabaseTestTrait;
 
-    protected $token;
+    protected $adminToken;
+    protected $userToken;
     protected $seed = TestSeeder::class;
     protected $migrate = true;
     protected $namespace = null;
@@ -35,7 +36,7 @@ class TagsApiTest extends CIUnitTestCase
     {
         $this->createTestTag();
 
-        $result = $this->withHeaders($this->getHeaders())
+        $result = $this->withHeaders($this->getAdminHeaders())
             ->get('/api/v1/tags');
 
         $result->assertStatus(200);
@@ -55,7 +56,7 @@ class TagsApiTest extends CIUnitTestCase
     {
         $tagId = $this->createTestTag();
 
-        $result = $this->withHeaders($this->getHeaders())
+        $result = $this->withHeaders($this->getAdminHeaders())
             ->get("/api/v1/tags/{$tagId}");
 
         $result->assertStatus(200);
@@ -76,7 +77,7 @@ class TagsApiTest extends CIUnitTestCase
             'name' => '테스트태그' . time(),
         ];
 
-        $result = $this->withHeaders($this->getHeaders())
+        $result = $this->withHeaders($this->getAdminHeaders())
             ->withBodyFormat('json')
             ->post('/api/v1/tags', $tagData);
 
@@ -98,7 +99,7 @@ class TagsApiTest extends CIUnitTestCase
             'name' => '수정된테스트태그' . time(),
         ];
 
-        $result = $this->withHeaders($this->getHeaders())
+        $result = $this->withHeaders($this->getAdminHeaders())
             ->withBodyFormat('json')
             ->put("/api/v1/tags/{$tagId}", $updateData);
 
@@ -116,7 +117,7 @@ class TagsApiTest extends CIUnitTestCase
     {
         $tagId = $this->createTestTag();
 
-        $result = $this->withHeaders($this->getHeaders())
+        $result = $this->withHeaders($this->getAdminHeaders())
             ->delete("/api/v1/tags/{$tagId}");
 
         $result->assertStatus(204);
@@ -131,7 +132,7 @@ class TagsApiTest extends CIUnitTestCase
     {
         $tagId = $this->createTestTag();
 
-        $result = $this->withHeaders($this->getHeaders())
+        $result = $this->withHeaders($this->getAdminHeaders())
             ->get("/api/v1/tags/{$tagId}/posts");
 
         $result->assertStatus(200);
@@ -140,18 +141,125 @@ class TagsApiTest extends CIUnitTestCase
         $this->assertIsArray($json->data->items);
     }
 
+    /**
+     * @test
+     * GET /api/v1/tags
+     * 인증없이 태그 목록 조회
+     */
+    public function test_get_tags_without_token_returns_unauthorized(): void
+    {
+        $result = $this->get('/api/v1/tags');
+
+        $result->assertStatus(401);
+    }
+
+    /**
+     * @test
+     * GET /api/v1/tags/{id}
+     * 존재하지 않는 태그 조회
+     */
+    public function test_get_tag_with_not_exists_id_returns_not_found(): void
+    {
+        $result = $this->withHeaders($this->getAdminHeaders())
+            ->get('/api/v1/tags/999999');
+
+        $result->assertStatus(404);
+    }
+
+    /**
+     * @test
+     * PUT /api/v1/tags/{id}
+     * 존재하지 않는 태그 수정 시도
+     */
+    public function test_update_tag_with_not_exists_id_returns_not_found(): void
+    {
+        $updateData = [
+            'name' => '수정된테스트태그' . time(),
+        ];
+
+        $result = $this->withHeaders($this->getAdminHeaders())
+            ->withBodyFormat('json')
+            ->put("/api/v1/tags/999999", $updateData);
+
+        $result->assertStatus(404);
+    }
+
+    /**
+     * @test
+     * PUT /api/v1/tags/{id}
+     * 존재하지 않는 태그에 Invalid Payload로 요청시 404 응답 - 방어선 순서 회귀 방지
+     */
+    public function test_update_tag_returns_not_found_with_invalid_payload(): void
+    {
+        $updateData = [
+            'name' => '',
+        ];
+
+        $result = $this->withHeaders($this->getAdminHeaders())
+            ->withBodyFormat('json')
+            ->put("/api/v1/tags/999999", $updateData);
+
+        $result->assertStatus(404);
+    }
+
+    /**
+     * @test
+     * DELETE /api/v1/tags/{id}
+     * 존재하지 않는 태그 삭제 시도
+     */
+    public function test_delete_tag_with_not_exists_id_returns_not_found(): void
+    {
+        $result = $this->withHeaders($this->getAdminHeaders())
+            ->delete("/api/v1/tags/999999");
+
+        $result->assertStatus(404);
+    }
+
+    /**
+     * @test
+     * POST /api/v1/tags
+     * 빈 name으로 요청시 422 응답
+     */
+    public function test_create_tag_without_name_returns_unprocessable_entity(): void
+    {
+        $tagData = [
+            'name' => '',
+        ];
+
+        $result = $this->withHeaders($this->getAdminHeaders())
+            ->withBodyFormat('json')
+            ->post('/api/v1/tags', $tagData);
+
+        $result->assertStatus(422);
+    }
+
+    /**
+     * @test
+     * POST /api/v1/tags
+     * user 그룹(tags.manage 권한 없음)으로 태그 생성 시도시 403 응답
+     */
+    public function test_create_tag_with_user_group_returns_forbidden(): void
+    {
+        $tagData = ['name' => '일반유저태그'];
+
+        $result = $this->withHeaders($this->getUserHeaders())
+            ->withBodyFormat('json')
+            ->post('/api/v1/tags', $tagData);
+
+        $result->assertStatus(403);
+    }
+
     protected function createTestTag(): int
     {
-        if (!$this->token) {
+        if (!$this->adminToken) {
             $this->loginAsAdmin();
         }
 
-        $headers = ['Authorization' => 'Bearer ' . $this->token];
         $payload = [
             'name' => '테스트태그' . time(),
         ];
 
-        $result = $this->withHeaders($headers)
+        $result = $this->withHeaders($this->getAdminHeaders())
             ->withBodyFormat('json')
             ->post('/api/v1/tags', $payload);
 
@@ -171,15 +279,37 @@ class TagsApiTest extends CIUnitTestCase
 
         $json = json_decode($result->getJSON());
 
-        $this->token = $json->token ?? null;
+        $this->adminToken = $json->token ?? null;
     }
 
-    protected function getHeaders()
+    protected function loginAsUser(): void
     {
-        if (!$this->token) {
+        $result = $this->withBodyFormat('json')
+            ->post('/api/v1/auth/login', [
+                'email' => 'user@example.com',
+                'password' => 'password123'
+            ]);
+
+        $json = json_decode($result->getJSON());
+
+        $this->userToken = $json->token ?? null;
+    }
+
+    protected function getAdminHeaders()
+    {
+        if (!$this->adminToken) {
             $this->loginAsAdmin();
         }
 
-        return ['Authorization' => 'Bearer ' . $this->token];
+        return ['Authorization' => 'Bearer ' . $this->adminToken];
+    }
+
+    protected function getUserHeaders()
+    {
+        if (!$this->userToken) {
+            $this->loginAsUser();
+        }
+
+        return ['Authorization' => 'Bearer ' . $this->userToken];
     }
 }

--- a/tests/api/TagsApiTest.php
+++ b/tests/api/TagsApiTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Api;
+
+use App\Database\Seeds\TestSeeder;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\FeatureTestTrait;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('api')]
+class TagsApiTest extends CIUnitTestCase
+{
+    use FeatureTestTrait;
+    use DatabaseTestTrait;
+
+    protected $token;
+    protected $seed = TestSeeder::class;
+    protected $migrate = true;
+    protected $namespace = null;
+    protected $refresh = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetServices();
+    }
+
+    /**
+     * @test
+     * GET /api/v1/tags
+     * 태그 목록 조회 (인증필요)
+     */
+    public function test_get_tags_list(): void
+    {
+        $this->createTestTag();
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->get('/api/v1/tags');
+
+        $result->assertStatus(200);
+        $result->assertJSONFragment(['status' => 'success']);
+
+        $json = json_decode($result->getJSON());
+        $this->assertObjectHasProperty('data', $json);
+        $this->assertIsArray($json->data->items);
+    }
+
+    /**
+     * @test
+     * GET /api/v1/tags/{id}
+     * 태그 단건 조회 (인증필요)
+     */
+    public function test_get_tag_by_id(): void
+    {
+        $tagId = $this->createTestTag();
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->get("/api/v1/tags/{$tagId}");
+
+        $result->assertStatus(200);
+        $json = json_decode($result->getJSON());
+        $this->assertEquals($tagId, $json->id);
+    }
+
+    /**
+     * @test
+     * POST /api/v1/tags
+     * 태그 생성 (Admin 권한 필요)
+     */
+    public function test_create_tag_with_admin_role(): void
+    {
+        $this->loginAsAdmin();
+
+        $tagData = [
+            'name' => '테스트태그' . time(),
+        ];
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->withBodyFormat('json')
+            ->post('/api/v1/tags', $tagData);
+
+        $result->assertStatus(201);
+        $json = json_decode($result->getJSON());
+        $this->assertEquals($tagData['name'], $json->name);
+    }
+
+    /**
+     * @test
+     * PUT /api/v1/tags/{id}
+     * 태그 수정 (Admin 권한 필요)
+     */
+    public function test_update_tag_with_admin_role(): void
+    {
+        $tagId = $this->createTestTag();
+
+        $updateData = [
+            'name' => '수정된테스트태그' . time(),
+        ];
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->withBodyFormat('json')
+            ->put("/api/v1/tags/{$tagId}", $updateData);
+
+        $result->assertStatus(200);
+        $json = json_decode($result->getJSON());
+        $this->assertEquals($updateData['name'], $json->data->name);
+    }
+
+    /**
+     * @test
+     * DELETE /api/v1/tags/{id}
+     * 태그 삭제 (Admin 권한 필요)
+     */
+    public function test_delete_tag_with_admin_role(): void
+    {
+        $tagId = $this->createTestTag();
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->delete("/api/v1/tags/{$tagId}");
+
+        $result->assertStatus(204);
+    }
+
+    /**
+     * @test
+     * GET /api/v1/tags/{id}/posts
+     * 태그에 속한 게시글 목록 조회 (Admin 권한 필요)
+     */
+    public function test_get_tag_posts(): void
+    {
+        $tagId = $this->createTestTag();
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->get("/api/v1/tags/{$tagId}/posts");
+
+        $result->assertStatus(200);
+        $json = json_decode($result->getJSON());
+        $this->assertObjectHasProperty('data', $json);
+        $this->assertIsArray($json->data->items);
+    }
+
+    protected function createTestTag(): int
+    {
+        if (!$this->token) {
+            $this->loginAsAdmin();
+        }
+
+        $headers = ['Authorization' => 'Bearer ' . $this->token];
+        $payload = [
+            'name' => '테스트태그' . time(),
+        ];
+
+        $result = $this->withHeaders($headers)
+            ->withBodyFormat('json')
+            ->post('/api/v1/tags', $payload);
+
+        $json = json_decode($result->getJSON());
+        $this->assertNotNull($json->id ?? null, 'createTestTag failed: ' . $result->getJSON());
+
+        return (int)$json->id;
+    }
+
+    protected function loginAsAdmin(): void
+    {
+        $result = $this->withBodyFormat('json')
+            ->post('/api/v1/auth/login', [
+                'email'    => 'admin@example.com',
+                'password' => 'password123'
+            ]);
+
+        $json = json_decode($result->getJSON());
+
+        $this->token = $json->token ?? null;
+    }
+
+    protected function getHeaders()
+    {
+        if (!$this->token) {
+            $this->loginAsAdmin();
+        }
+
+        return ['Authorization' => 'Bearer ' . $this->token];
+    }
+}

--- a/tests/unit/TransformerTest.php
+++ b/tests/unit/TransformerTest.php
@@ -61,10 +61,10 @@ class TransformerTest extends CIUnitTestCase
     public function post_transformer_serializes_enum_status_to_string(): void
     {
         $resource = [
-            'id' => 1, 'title' => 'T', 'slug' => 's', 'content' => 'c',
-            'state'       => PostState::Draft,
-            'writer_id'   => 1,
-            'created_at'  => null, 'updated_at' => null,
+            'id'         => 1, 'title' => 'T', 'slug' => 's', 'content' => 'c',
+            'state'      => PostState::Draft,
+            'writer_id'  => 1,
+            'created_at' => null, 'updated_at' => null,
         ];
 
         $result = (new PostTransformer())->transform($resource);
@@ -77,7 +77,7 @@ class TransformerTest extends CIUnitTestCase
     public function post_transformer_accepts_string_status(): void
     {
         $resource = [
-            'id' => 1, 'title' => 'T', 'slug' => 's', 'content' => 'c',
+            'id'         => 1, 'title' => 'T', 'slug' => 's', 'content' => 'c',
             'state'      => 'archived',
             'writer_id'  => 1,
             'created_at' => null, 'updated_at' => null,
@@ -91,8 +91,8 @@ class TransformerTest extends CIUnitTestCase
     #[Test]
     public function post_transformer_allowed_fields_covers_all_public_fields(): void
     {
-        $transformer   = new PostTransformer();
-        $reflection    = new \ReflectionMethod($transformer, 'getAllowedFields');
+        $transformer = new PostTransformer();
+        $reflection = new \ReflectionMethod($transformer, 'getAllowedFields');
         $allowedFields = $reflection->invoke($transformer);
 
         $this->assertContains('id', $allowedFields);
@@ -106,8 +106,8 @@ class TransformerTest extends CIUnitTestCase
     #[Test]
     public function post_transformer_allowed_includes(): void
     {
-        $transformer     = new PostTransformer();
-        $reflection      = new \ReflectionMethod($transformer, 'getAllowedIncludes');
+        $transformer = new PostTransformer();
+        $reflection = new \ReflectionMethod($transformer, 'getAllowedIncludes');
         $allowedIncludes = $reflection->invoke($transformer);
 
         $this->assertContains('category', $allowedIncludes);
@@ -143,7 +143,7 @@ class TransformerTest extends CIUnitTestCase
     public function category_transformer_disables_includes_until_implemented(): void
     {
         $transformer = new CategoryTransformer();
-        $reflection  = new \ReflectionMethod($transformer, 'getAllowedIncludes');
+        $reflection = new \ReflectionMethod($transformer, 'getAllowedIncludes');
 
         $this->assertSame([], $reflection->invoke($transformer));
     }
@@ -156,15 +156,17 @@ class TransformerTest extends CIUnitTestCase
     public function tag_transformer_returns_expected_fields(): void
     {
         $resource = [
-            'id' => 1, 'name' => 'PHP', 'slug' => 'php',
-            'created_at' => null, 'updated_at' => null,
+            'id'         => 1,
+            'name'       => 'PHP',
+            'created_at' => null,
+            'updated_at' => null,
         ];
 
         $result = (new TagTransformer())->transform($resource);
 
         $this->assertSame(1, $result['id']);
         $this->assertSame('PHP', $result['name']);
-        $this->assertSame('php', $result['slug']);
+        $this->assertArrayNotHasKey('slug', $result);
     }
 
     // -------------------------------------------------------------------------
@@ -197,7 +199,7 @@ class TransformerTest extends CIUnitTestCase
     public function comment_transformer_disables_includes_until_implemented(): void
     {
         $transformer = new CommentTransformer();
-        $reflection  = new \ReflectionMethod($transformer, 'getAllowedIncludes');
+        $reflection = new \ReflectionMethod($transformer, 'getAllowedIncludes');
 
         $this->assertSame([], $reflection->invoke($transformer));
     }
@@ -235,8 +237,8 @@ class TransformerTest extends CIUnitTestCase
     public function media_transformer_accepts_string_type(): void
     {
         $resource = [
-            'id' => 1, 'filename' => 'f', 'original_name' => 'o',
-            'mime_type' => 'video/mp4', 'path' => '/p',
+            'id'         => 1, 'filename' => 'f', 'original_name' => 'o',
+            'mime_type'  => 'video/mp4', 'path' => '/p',
             'type'       => 'video',
             'created_at' => null, 'updated_at' => null,
         ];
@@ -272,8 +274,8 @@ class TransformerTest extends CIUnitTestCase
     #[Test]
     public function user_transformer_allowed_fields_excludes_email_and_password(): void
     {
-        $transformer   = new UserTransformer();
-        $reflection    = new \ReflectionMethod($transformer, 'getAllowedFields');
+        $transformer = new UserTransformer();
+        $reflection = new \ReflectionMethod($transformer, 'getAllowedFields');
         $allowedFields = $reflection->invoke($transformer);
 
         $this->assertNotContains('email', $allowedFields);
@@ -307,8 +309,8 @@ class TransformerTest extends CIUnitTestCase
     #[Test]
     public function auth_user_transformer_allowed_fields_includes_email(): void
     {
-        $transformer   = new AuthUserTransformer();
-        $reflection    = new \ReflectionMethod($transformer, 'getAllowedFields');
+        $transformer = new AuthUserTransformer();
+        $reflection = new \ReflectionMethod($transformer, 'getAllowedFields');
         $allowedFields = $reflection->invoke($transformer);
 
         $this->assertContains('email', $allowedFields);


### PR DESCRIPTION
## Summary
- TagsController CRUD 구현 (index/show/create/update/delete/posts)
- PostModel::syncTags() 트랜잭션 + 테넌트별 tag_id 검증
- PostTransformer includeTags 강제 (show/create/update 응답에 항상 포함)
- OpenAPI Tag 스키마 + /tags/{id}/posts 엔드포인트 추가

## 주요 결정
- 입력 필드명: `tags` (ID 배열)
- 응답 포함 방식: Transformer includeTags + show()에서 강제
- tags-only 업데이트 지원 (`if_exist` rule, `nullable` 패턴으로 없음/빈배열 구분)
- `posts()` 위치: `TagModel::findByPost` / `findByTag`

## 부채 fix (이번 PR에서 함께 처리)
- CategorySeeder slug 누락 → CategoryModel 사용
- CategoriesApiTest line 162 syntax
- Routes.php 서브 라우트가 resource() `(:any)`에 먹히던 순서 문제
- PostsController update() `\$id` int 캐스트 (syncTags TypeError)
- TagsController `permission` → `apipermission` 어트리뷰트 (403 JSON 응답 정상화)

## 남은 작업 (별도 이슈로 분리됨)
- #99 PostsController::show() 테넌트 격리 누락
- #103 API 응답 형식 일관성 통일
- #104 CategoriesController/CommentsController apipermission 전환
- #105 syncTags 다른 테넌트 tag_id silent filter 버그

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 태그 관리 시스템 추가 (생성, 조회, 수정, 삭제)
- 게시물에 태그 첨부 및 관리 기능 추가
- 태그별 게시물 조회 엔드포인트 추가
- 태그 관리 권한 설정 추가

## 문서
- API 문서에 태그 관련 엔드포인트 및 스키마 추가

## 테스트
- 태그 API 기능 테스트 추가
- 게시물 태그 동기화 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->