### PR TITLE
🐛 fix: syncTags 다른 테넌트 tag_id 유실 버그 (#105)

### DIFF
--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -6,9 +6,9 @@ use App\Entities\PostEntity;
 use App\Enums\UserRole;
 use App\Models\PostModel;
 use App\Transformers\PostTransformer;
-use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Router\Attributes\Filter;
+use CodeIgniter\Shield\Models\DatabaseException;
 use InvalidArgumentException;
 
 /**
@@ -120,32 +120,21 @@ class PostsController extends BaseApiController
         $payload['state'] = 'draft';
         $payload['tenant_id'] = auth()->user()->tenant_id;
 
-        $tagIds = $this->extractTagIdsFromPayload($payload);
+        $tags = $this->extractTagIdsFromPayload($payload);
         unset($payload['tags']);
 
-        $db = db_connect();
-        $db->transBegin();
-
         try {
-            $this->model->insert($payload);
-
-            $postId = $this->model->getInsertID();
-
-            if ($tagIds !== null) {
-                $this->model->syncTags($postId, $tagIds, $payload['tenant_id']);
-            }
-
-            $db->transCommit();
+            $createdPost = $this->model->createWithTags($payload, $tags);
         } catch (InvalidArgumentException $error) {
-            $db->transRollback();
             return $this->failValidationErrors(['tags' => $error->getMessage()]);
         } catch (DatabaseException $exception) {
-            $db->transRollback();
             log_message('error', $exception->getMessage());
             return $this->failServerError('Database error');
         }
 
-        $createdPost = $this->model->find($postId);
+        if ($createdPost === null) {
+            return $this->failServerError('Failed to create post');
+        }
 
         return $this->responseWithItem($this->transformer->transformWithTags($createdPost), 201);
     }
@@ -183,40 +172,27 @@ class PostsController extends BaseApiController
 
         $allowedPayload = array_intersect_key($payload, $rules);
 
-        $tagIds = $this->extractTagIdsFromPayload($allowedPayload);
+        $tags = $this->extractTagIdsFromPayload($allowedPayload);
         unset($allowedPayload['tags']);
 
-        if (!$allowedPayload && $tagIds === null) {
+        if (!$allowedPayload && $tags === null) {
             return $this->failValidationErrors('No valid data provided');
         }
 
-        $id = (int)$id;
-
-        $db = db_connect();
-        $db->transBegin();
-
         try {
-            if ($allowedPayload) {
-                $this->model->update($id, $allowedPayload);
-            }
-
-            if ($tagIds !== null) {
-                $this->model->syncTags($id, $tagIds, $post->tenant_id);
-            }
-
-            $db->transCommit();
+            $updatePost = $this->model->updateWithTags((int)$id, $allowedPayload, $tags, $post->tenant_id);
         } catch (InvalidArgumentException $error) {
-            $db->transRollback();
             return $this->failValidationErrors(['tags' => $error->getMessage()]);
         } catch (DatabaseException $exception) {
-            $db->transRollback();
             log_message('error', $exception->getMessage());
             return $this->failServerError('Database error');
         }
 
-        $updatedPost = $this->model->find($id);
+        if ($updatePost === null) {
+            return $this->failServerError('Failed to update post');
+        }
 
-        return $this->responseWithItem($this->transformer->transformWithTags($updatedPost));
+        return $this->responseWithItem($this->transformer->transformWithTags($updatePost));
     }
 
     /**

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -123,6 +123,9 @@ class PostsController extends BaseApiController
         $tagIds = $this->extractTagIdsFromPayload($payload);
         unset($payload['tags']);
 
+        $db = db_connect();
+        $db->transBegin();
+
         try {
             $this->model->insert($payload);
 
@@ -131,9 +134,13 @@ class PostsController extends BaseApiController
             if ($tagIds !== null) {
                 $this->model->syncTags($postId, $tagIds, $payload['tenant_id']);
             }
+
+            $db->transCommit();
         } catch (InvalidArgumentException $error) {
+            $db->transRollback();
             return $this->failValidationErrors(['tags' => $error->getMessage()]);
         } catch (DatabaseException $exception) {
+            $db->transRollback();
             log_message('error', $exception->getMessage());
             return $this->failServerError('Database error');
         }
@@ -185,6 +192,9 @@ class PostsController extends BaseApiController
 
         $id = (int)$id;
 
+        $db = db_connect();
+        $db->transBegin();
+
         try {
             if ($allowedPayload) {
                 $this->model->update($id, $allowedPayload);
@@ -193,13 +203,16 @@ class PostsController extends BaseApiController
             if ($tagIds !== null) {
                 $this->model->syncTags($id, $tagIds, $post->tenant_id);
             }
+
+            $db->transCommit();
         } catch (InvalidArgumentException $error) {
+            $db->transRollback();
             return $this->failValidationErrors(['tags' => $error->getMessage()]);
         } catch (DatabaseException $exception) {
+            $db->transRollback();
             log_message('error', $exception->getMessage());
             return $this->failServerError('Database error');
         }
-
 
         $updatedPost = $this->model->find($id);
 

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -9,6 +9,7 @@ use App\Transformers\PostTransformer;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Router\Attributes\Filter;
+use InvalidArgumentException;
 
 /**
  * Posts API 컨트롤러
@@ -130,6 +131,8 @@ class PostsController extends BaseApiController
             if ($tagIds !== null) {
                 $this->model->syncTags($postId, $tagIds, $payload['tenant_id']);
             }
+        } catch (InvalidArgumentException $error) {
+            return $this->failValidationErrors(['tags' => $error->getMessage()]);
         } catch (DatabaseException $exception) {
             log_message('error', $exception->getMessage());
             return $this->failServerError('Database error');
@@ -190,6 +193,8 @@ class PostsController extends BaseApiController
             if ($tagIds !== null) {
                 $this->model->syncTags($id, $tagIds, $post->tenant_id);
             }
+        } catch (InvalidArgumentException $error) {
+            return $this->failValidationErrors(['tags' => $error->getMessage()]);
         } catch (DatabaseException $exception) {
             log_message('error', $exception->getMessage());
             return $this->failServerError('Database error');

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -2,12 +2,18 @@
 
 namespace App\Models;
 
+use Throwable;
+use Faker\Generator;
+use CodeIgniter\Model;
+use InvalidArgumentException;
 use App\Entities\PostEntity;
 use App\Traits\SlugGeneratorTrait;
-use CodeIgniter\Model;
-use Faker\Generator;
-use InvalidArgumentException;
 
+/**
+ * @method PostEntity|null find($id = null)
+ * @method PostEntity[]   findAll(int $limit = 0, int $offset = 0)
+ * @method PostEntity|null first()
+ */
 class PostModel extends Model
 {
     use SlugGeneratorTrait;
@@ -112,6 +118,74 @@ class PostModel extends Model
         }
 
         $this->db->transComplete();
+    }
+
+    public function createWithTags(array $payload, ?array $tags): ?PostEntity
+    {
+        $this->db->transBegin();
+
+        try {
+            $result = $this->insert($payload);
+
+            if (!$result) {
+                $this->db->transRollback();
+                log_message('error', '[post.create] Insert failed', ['errors' => $this->errors()]);
+                return null;
+            }
+
+            $postId = $this->getInsertID();
+
+            if ($tags !== null) {
+                $this->syncTags($postId, $tags, $payload['tenant_id']);
+            }
+
+            if (!$this->db->transStatus()) {
+                $this->db->transRollback();
+                log_message('error', '[post.create] Transaction failed', ['db_error' => $this->db->error()]);
+                return null;
+            }
+
+            $this->db->transCommit();
+
+            return $this->find($postId);
+        } catch (Throwable $throwable) {
+            $this->db->transRollback();
+            throw $throwable;
+        }
+    }
+
+    public function updateWithTags(int $id, array $payload, ?array $tags, int $tenantId): ?PostEntity
+    {
+        $this->db->transBegin();
+
+        try {
+            if ($payload) {
+                $result = $this->update($id, $payload);
+
+                if (!$result) {
+                    $this->db->transRollback();
+                    log_message('error', '[post.update] Update failed', ['errors' => $this->errors()]);
+                    return null;
+                }
+            }
+
+            if ($tags !== null) {
+                $this->syncTags($id, $tags, $tenantId);
+            }
+
+            if (!$this->db->transStatus()) {
+                $this->db->transRollback();
+                log_message('error', '[post.update] Transaction failed', ['db_error' => $this->db->error()]);
+                return null;
+            }
+
+            $this->db->transCommit();
+
+            return $this->find($id);
+        } catch (Throwable $throwable) {
+            $this->db->transRollback();
+            throw $throwable;
+        }
     }
 
     private function deleteOldTags(int $postId, int $tenantId): void

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -6,6 +6,7 @@ use App\Entities\PostEntity;
 use App\Traits\SlugGeneratorTrait;
 use CodeIgniter\Model;
 use Faker\Generator;
+use InvalidArgumentException;
 
 class PostModel extends Model
 {
@@ -81,8 +82,6 @@ class PostModel extends Model
             return;
         }
 
-        $this->db->transStart();
-
         // tenant validation
         $results = $this->db->table('tags')
             ->select('id')
@@ -92,6 +91,12 @@ class PostModel extends Model
             ->getResultArray();
 
         $validTagIds = array_column($results, 'id');
+
+        if (count($validTagIds) !== count($tagIds)) {
+            throw new InvalidArgumentException('Invalid tag ids: ' . implode(', ', array_diff($tagIds, $validTagIds)));
+        }
+
+        $this->db->transStart();
 
         // delete old tags
         $this->deleteOldTags($postId, $tenantId);

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -811,6 +811,7 @@ class PostsApiTest extends CIUnitTestCase
         list($loginUser, $post) = $this->createDifferentOwnerPosts();
         $tags = $this->createFakeTags(4);
         $this->attachTags($post->id, [$tags[0]->id, $tags[1]->id]);
+        $oldTitle = $post->title;
 
         $result = $this->withHeaders($this->getHeaders($loginUser))
             ->put("/api/v1/posts/{$post->id}", [
@@ -819,6 +820,7 @@ class PostsApiTest extends CIUnitTestCase
             ]);
 
         $result->assertStatus(403);
+        $this->seeInDatabase('posts', ['id' => $post->id, 'title' => $oldTitle]);
         $this->seeNumRecords(2, 'post_tags', ['post_id' => $post->id]);
         $this->seeInDatabase('post_tags', ['post_id' => $post->id, 'tag_id' => $tags[0]->id]);
         $this->seeInDatabase('post_tags', ['post_id' => $post->id, 'tag_id' => $tags[1]->id]);
@@ -836,6 +838,7 @@ class PostsApiTest extends CIUnitTestCase
         $tenantId = $this->createOtherTenant();
         $otherTenantTags = $this->createTagInTenant($tenantId, 2);
         $postId = $this->createTestPost();
+        $oldTitle = $this->testPost['title'];
         $oldTags = $this->createFakeTags(2);
 
         $this->attachTags($postId, [$oldTags[0]->id, $oldTags[1]->id]);
@@ -846,6 +849,7 @@ class PostsApiTest extends CIUnitTestCase
                 'tags'  => [$otherTenantTags[0]->id, $otherTenantTags[1]->id],
             ]);
 
+        $this->seeInDatabase('posts', ['id' => $postId, 'title' => $oldTitle]);
         $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $oldTags[0]->id]);
         $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $oldTags[1]->id]);
         $this->dontSeeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $otherTenantTags[0]->id]);

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -815,7 +815,7 @@ class PostsApiTest extends CIUnitTestCase
         $result = $this->withHeaders($this->getHeaders($loginUser))
             ->put("/api/v1/posts/{$post->id}", [
                 'title' => 'Updated Title',
-                'tags' => [$tags[2]->id, $tags[3]->id],
+                'tags'  => [$tags[2]->id, $tags[3]->id],
             ]);
 
         $result->assertStatus(403);
@@ -824,6 +824,33 @@ class PostsApiTest extends CIUnitTestCase
         $this->seeInDatabase('post_tags', ['post_id' => $post->id, 'tag_id' => $tags[1]->id]);
         $this->dontSeeInDatabase('post_tags', ['post_id' => $post->id, 'tag_id' => $tags[2]->id]);
         $this->dontSeeInDatabase('post_tags', ['post_id' => $post->id, 'tag_id' => $tags[3]->id]);
+    }
+
+    /**
+     * PUT /api/v1/posts/{id}
+     *
+     * 다른 테넌트의 태그 ID를 포함한 업데이트 요청은 422 오류 리턴 테스트
+     */
+    public function test_update_post_rejects_tag_ids_from_other_tenant(): void
+    {
+        $tenantId = $this->createOtherTenant();
+        $otherTenantTags = $this->createTagInTenant($tenantId, 2);
+        $postId = $this->createTestPost();
+        $oldTags = $this->createFakeTags(2);
+
+        $this->attachTags($postId, [$oldTags[0]->id, $oldTags[1]->id]);
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->put("/api/v1/posts/$postId", [
+                'title' => 'Updated Title',
+                'tags'  => [$otherTenantTags[0]->id, $otherTenantTags[1]->id],
+            ]);
+
+        $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $oldTags[0]->id]);
+        $this->seeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $oldTags[1]->id]);
+        $this->dontSeeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $otherTenantTags[0]->id]);
+        $this->dontSeeInDatabase('post_tags', ['post_id' => $postId, 'tag_id' => $otherTenantTags[1]->id]);
+        $result->assertStatus(422);
     }
 
     /**
@@ -951,4 +978,22 @@ class PostsApiTest extends CIUnitTestCase
         );
     }
 
+    private function createOtherTenant(): int
+    {
+        $this->db->table('tenants')
+            ->insert([
+                'subdomain' => 'other-tenant',
+                'name'      => 'other',
+            ]);
+
+        return $this->db->insertID();
+    }
+
+    private function createTagInTenant(int $tenantId, int $count): array
+    {
+        $fabricator = new Fabricator(TagModel::class);
+        $tags = $fabricator->setOverrides(['tenant_id' => $tenantId])->create($count);
+
+        return $tags;
+    }
 }


### PR DESCRIPTION
## Summary

- 다른 테넌트의 `tag_id`가 `syncTags()`에서 silent filter 되어 **기존 태그까지 유실**되고 200 OK로 응답되던 버그를 수정
- TDD 사이클로 진행: 1) Red 재현 테스트 커밋 → 2) Model validation + tx 재배치 + Controller catch 커밋
- `validation(select/count)` 을 `transStart` 이전으로 이동. tx 안에서 예외 던지면 `transComplete` 호출이 스킵되어 연결에 열린 트랜잭션이 남고, 이후 `migrate:refresh`를 깨뜨리는 문제까지 동반 해결

## Root Cause

`PostModel::syncTags()`:
1. `whereIn('id', $tagIds)->where('tenant_id', $tenantId)` 로 다른 테넌트 tag_id를 조용히 제외
2. 개수 차이 검증 없이 `deleteOldTags()` 먼저 실행 → 기존 태그 삭제
3. 필터 후 `$validTagIds`가 비면 `insertBatch` 스킵 → **post_tags 빈 상태로 커밋**
4. Controller는 정상 200 OK 응답 → 클라이언트는 저장 실패 인지 못함

## Fix

- `PostModel::syncTags()`: `count($validTagIds) !== count($tagIds)` 이면 `\InvalidArgumentException` throw. 유효하지 않은 id들을 메시지에 포함 (`array_diff`)
- Validation을 `transStart` 이전으로 이동. 트랜잭션은 delete + insertBatch만 감싸도록 재배치
- `PostsController::create() / update()`: `InvalidArgumentException` catch 추가 → `failValidationErrors(['tags' => ...])` 로 422 응답

## Test plan

- [x] 신규 테스트 `test_update_post_rejects_tag_ids_from_other_tenant` Green
  - 422 응답 / 기존 태그 보존(seeInDatabase) / 잘못된 태그 거부(dontSeeInDatabase)
- [x] `PostsApiTest` 전체 36/36 pass (이전 35개 + 신규 1개)
- [x] `TagsApiTest` 전체 13/13 pass
- [x] Api 스위트 전체: 기존 부채(CategoriesApiTest 5건, CommentsApiTest 9건) 외 **새로운 실패 0건**

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 태그 할당 시 입력 검증 강화: 유효하지 않은 태그 ID는 거부되고, 잘못된 ID 목록을 포함한 검증 오류(태그 필드에 연결) 반환
  * 게시물 생성/수정에서 영속화 실패 시 명시적 서버 오류 반환 및 트랜잭션 안전성 향상
  * 태그 동기화 전 검증으로 불필요한 트랜잭션 방지 및 일관성 보호

* **테스트**
  * 다른 테넌트의 태그 ID 거부 동작 검증 테스트 추가
  * 권한 없는 업데이트 시 원본 게시물 변경되지 않음을 확인하는 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->