### PR TITLE
🐛 fix: tags 입력 검증 강화 + 중복 tag_id dedupe (#108)

### DIFF
--- a/app/Config/Validation.php
+++ b/app/Config/Validation.php
@@ -2,6 +2,7 @@
 
 namespace Config;
 
+use App\Validation\TagRules;
 use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Validation\StrictRules\CreditCardRules;
 use CodeIgniter\Validation\StrictRules\FileRules;
@@ -25,6 +26,7 @@ class Validation extends BaseConfig
         FormatRules::class,
         FileRules::class,
         CreditCardRules::class,
+        TagRules::class,
     ];
 
     /**

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -103,7 +103,7 @@ class PostsController extends BaseApiController
             'title'       => 'required|min_length[3]|max_length[255]',
             'content'     => 'required|min_length[10]',
             'category_id' => 'required|integer|is_not_unique[categories.id]',
-            'tags'        => 'permit_empty|is_array|is_array_of_int',
+            'tags'        => 'if_exist|is_array|is_array_of_int',
         ];
 
         $payload = $this->request->getJSON(true);

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -103,7 +103,7 @@ class PostsController extends BaseApiController
             'title'       => 'required|min_length[3]|max_length[255]',
             'content'     => 'required|min_length[10]',
             'category_id' => 'required|integer|is_not_unique[categories.id]',
-            'tags'        => 'permit_empty|is_array',
+            'tags'        => 'permit_empty|is_array|is_array_of_int',
         ];
 
         $payload = $this->request->getJSON(true);
@@ -151,7 +151,7 @@ class PostsController extends BaseApiController
             'title'       => 'if_exist|min_length[3]|max_length[255]',
             'content'     => 'if_exist|min_length[10]',
             'category_id' => 'if_exist|integer|is_not_unique[categories.id]',
-            'tags'        => 'if_exist|is_array',
+            'tags'        => 'if_exist|is_array|is_array_of_int',
         ];
 
         $post = $this->model->find($id);

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -83,6 +83,8 @@ class PostModel extends Model
 
     public function syncTags(int $postId, array $tagIds, int $tenantId): void
     {
+        $tagIds = array_unique($tagIds, SORT_NUMERIC);
+
         if (empty($tagIds)) {
             $this->deleteOldTags($postId, $tenantId);
             return;

--- a/app/Validation/TagRules.php
+++ b/app/Validation/TagRules.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Validation;
+
+class TagRules
+{
+    public function is_array_of_int($value, ?string &$error = null): bool
+    {
+        if (!is_array($value)) {
+            return false;
+        }
+
+        foreach ($value as $v) {
+            $valid = filter_var($v, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+
+            if ($valid === false) {
+                $error = 'The {field} field must contain positive integers only';
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -940,6 +940,32 @@ class PostsApiTest extends CIUnitTestCase
     }
 
     /**
+     * POST /api/v1/posts/
+     *
+     * 태그가 빈 문자열인 경우 포스트 생성 시 422 오류 리턴 테스트
+     */
+    public function test_create_post_rejects_empty_string_tags(): void
+    {
+        $this->loginAsAdmin();
+
+        $headers = $this->getHeaders();
+
+        $result = $this->withHeaders($headers)
+            ->withBodyFormat('json')
+            ->post('/api/v1/posts', [
+                'title' => '테스트 포스트',
+                'content' => '테스트 포스트 내용입니다.',
+                'category_id' => 1,
+                'tags' => '',
+            ]);
+
+        $result->assertStatus(422);
+
+        $json = json_decode($result->getJSON(), true);
+        $errors = $json['messages'] ?? $json['errors'] ?? [];
+        $this->assertArrayHasKey('tags', $errors);
+    }
+    /**
      * GET /api/v1/posts/{id}/comments
      *
      * 포스트 댓글 목록 조회 테스트 (미구현)

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -481,6 +481,72 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * POST /api/v1/posts
      *
+     * 태그 ID가 정수형이 아닌 경우 422 오류 리턴 테스트
+     */
+    public function test_create_post_rejects_non_integer_tag_ids(): void
+    {
+        $this->loginAsAdmin();
+
+        $headers = $this->getHeaders();
+
+        $result = $this->withHeaders($headers)->withBodyFormat('json')
+            ->post('/api/v1/posts', [
+                'title'       => '테스트 포스트',
+                'slug'        => 'test-post',
+                'content'     => '테스트 포스트 내용입니다.',
+                'excerpt'     => '포스트 요약',
+                'status'      => 'draft',
+                'category_id' => 1,
+                'tags'        => ['abc', null, 5]
+            ]);
+
+        $result->assertStatus(422);
+
+        $json = json_decode($result->getJSON(), true);
+        $errors = $json['messages'] ?? $json['errors'] ?? [];
+
+        $this->assertArrayHasKey('tags', $errors);
+        $this->assertStringNotContainsString('0', $errors['tags'] ?? '');
+    }
+
+    /**
+     * POST /api/v1/posts
+     *
+     * 태그 ID가 중복된 경우 중복 제거 테스트
+     */
+    public function test_create_post_with_duplicate_tag_ids_dedupes(): void
+    {
+        $tag = $this->createFakeTags(1);
+        $this->loginAsAdmin();
+
+        $headers = $this->getHeaders();
+
+        $result = $this->withHeaders($headers)->withBodyFormat('json')
+            ->post('/api/v1/posts', [
+                'title'       => '테스트 포스트',
+                'slug'        => 'test-post',
+                'content'     => '테스트 포스트 내용입니다.',
+                'excerpt'     => '포스트 요약',
+                'status'      => 'draft',
+                'category_id' => 1,
+                'tags'        => [$tag[0]->id, $tag[0]->id]
+            ]);
+
+        $result->assertStatus(201);
+
+        $createdPost = json_decode($result->getJSON())->data;
+        $postId = $createdPost->id;
+
+        $count = db_connect()->table('post_tags')
+            ->where('post_id', $postId)
+            ->where('tag_id', $tag[0]->id)
+            ->countAllResults();
+        $this->assertEquals(1, $count);
+    }
+
+    /**
+     * POST /api/v1/posts
+     *
      * 유효성 검증 실패 테스트
      */
     public function test_create_post_validates_required_fields(): void


### PR DESCRIPTION
## Summary

- `extractTagIdsFromPayload()`의 silent 0 변환 방지 (#108)
- PR #113 리뷰의 `syncTags` 중복 tag_id 오탐(false positive) 해결

## 변경

### 검증 강화 (#108)
- `App\Validation\TagRules::is_array_of_int` 신규 (FILTER_VALIDATE_INT, min_range 1)
- `Config\Validation::$ruleSets`에 등록
- `PostsController` create/update rules: `permit_empty|is_array|is_array_of_int` / `if_exist|is_array|is_array_of_int`
- 비정수(`'abc'`, `null`), 음수, `0` 모두 422 + 명시 메시지로 거부 (이전 silent 0 변환 → 모호한 에러)

### 중복 dedupe (PR #113 리뷰 응답)
- `PostModel::syncTags()` 시작 부분에 `array_unique($tagIds, SORT_NUMERIC)` 적용
- `[1, 1, 2]` 같은 중복 입력 정상 처리 (이전엔 `count` 비교에서 false positive 422 + 공란 메시지)

## TDD 사이클

- Red 커밋 `afbf647`: `test_create_post_rejects_non_integer_tag_ids`, `test_create_post_with_duplicate_tag_ids_dedupes` (모두 fail 확인)
- Green 커밋 `e1e31c4`: TagRules + array_unique 적용 (모두 pass)

## 결정 / 부채

- 검증 위치: Custom Validation Rule 클래스 (CI4 표준)
- 정제(dedupe) 위치: Model 레이어 (`syncTags`) — 호출자 무관 안전
- update 버전 테스트 + 복합 시나리오는 의도적으로 생략 — 같은 헬퍼/syncTags 코드 경로 거치므로 회귀 risk 동일
- 기존 PostsApiTest 36개 중복 검토는 별도 #117에서 진행

Closes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 태그 입력 유효성 검사 강화

* **버그 수정**
  * 중복 태그 ID 자동 제거 기능 추가
  * 잘못된 태그 형식에 대한 검증 오류 메시지 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->