### PR TITLE
🐛 fix: CategoriesApiTest CI 실패 5건 해결 (#114)

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -29,14 +29,16 @@ $routes->group('api/v1', static function ($routes): void {
     $routes->get('posts/(:num)', 'Api\V1\PostsController::show/$1');
     $routes->get('posts/(:num)/comments', 'Api\V1\PostsController::comments/$1');
 
+    $routes->get('categories/(:num)/posts', 'Api\V1\CategoriesController::posts/$1');
+    $routes->get('categories', 'Api\V1\CategoriesController::index');
+    $routes->get('categories/(:num)', 'Api\V1\CategoriesController::show/$1');
+
     // 인증 필요 엔드포인트 (tokens 필터)
     $routes->group('', ['filter' => 'tokens'], static function ($routes): void {
-        // 인증
         $routes->get('auth/me', 'Api\V1\AuthController::me');
         $routes->post('auth/logout', 'Api\V1\AuthController::logout');
         $routes->post('auth/refresh', 'Api\V1\AuthController::refresh');
 
-        // 테넌트 관리
         $routes->group('', ['filter' => 'apigroup:superadmin,admin'], static function ($routes): void {
             $routes->get('tenants', 'Api\V1\TenantsController::index');
             $routes->get('tenants/(:num)', 'Api\V1\TenantsController::show/$1');
@@ -49,36 +51,28 @@ $routes->group('api/v1', static function ($routes): void {
             $routes->delete('tenants/(:num)', 'Api\V1\TenantsController::delete/$1');
         });
 
-        // 사용자 그룹 관리
         $routes->get('users/(:num)/groups', 'Api\V1\UserGroupsController::index/$1');
         $routes->put('users/(:num)/groups', 'Api\V1\UserGroupsController::update/$1');
         $routes->delete('users/(:num)/groups', 'Api\V1\UserGroupsController::delete/$1');
 
-        // 사용자 관리
         $routes->resource('users', ['controller' => 'Api\V1\UsersController']);
 
         $routes->get('users/(:num)/roles', 'Api\V1\UsersController::roles/$1');
         $routes->put('users/(:num)/roles', 'Api\V1\UsersController::updateRoles/$1');
 
-        // 포스트
         $routes->post('posts', 'Api\V1\PostsController::create');
         $routes->put('posts/(:num)', 'Api\V1\PostsController::update/$1');
         $routes->delete('posts/(:num)', 'Api\V1\PostsController::delete/$1');
         $routes->post('posts/(:num)/publish', 'Api\V1\PostsController::publish/$1');
         $routes->post('posts/(:num)/unpublish', 'Api\V1\PostsController::unpublish/$1');
 
-        // 페이지 (#9)
         $routes->resource('pages', ['controller' => 'Api\V1\PagesController']);
         $routes->post('pages/(:num)/publish', 'Api\V1\PagesController::publish/$1');
 
-        // 카테고리 (#10)
-        // posts 서브 라우트를 resource()보다 먼저 등록해야 (:any) 와일드카드에 캡처되지 않음
-        $routes->get('categories/(:num)/posts', 'Api\V1\CategoriesController::posts/$1');
-        $routes->resource('categories', ['controller' => 'Api\V1\CategoriesController']);
-
-        // 태그 (#10)
         $routes->get('tags/(:num)/posts', 'Api\V1\TagsController::posts/$1');
         $routes->resource('tags', ['controller' => 'Api\V1\TagsController']);
+
+        $routes->resource('categories', ['controller' => 'Api\V1\CategoriesController', 'only' => ['create', 'update', 'delete']]);
 
         // 댓글 (#11)
         $routes->resource('comments', ['controller' => 'Api\V1\CommentsController']);

--- a/app/Controllers/Api/V1/CategoriesController.php
+++ b/app/Controllers/Api/V1/CategoriesController.php
@@ -33,24 +33,22 @@ class CategoriesController extends BaseApiController
         $this->transformer = new CategoryTransformer();
     }
 
-    #[Filter(by: 'tokens')]
     public function index(): ResponseInterface
     {
-        $categories = $this->model->where('tenant_id', auth()->user()->tenant_id)->findAll();
+        $categories = $this->model->findAll();
 
         return $this->responseWith($this->transformer->transformMany($categories));
     }
 
-    #[Filter(by: 'tokens')]
     public function show($id = null): ResponseInterface
     {
-        $category = $this->model->where('tenant_id', auth()->user()->tenant_id)->find($id);
+        $category = $this->model->find($id);
 
         if ($category === null) {
             return $this->failNotFound();
         }
 
-        return $this->respond($this->transformer->transform($category));
+        return $this->responseWithItem($this->transformer->transform($category));
     }
 
     #[Filter(by: 'tokens')]
@@ -84,7 +82,7 @@ class CategoriesController extends BaseApiController
 
         $createdCategory = $this->model->find($this->model->getInsertID());
 
-        return $this->respondCreated($this->transformer->transform($createdCategory));
+        return $this->responseWithItem($this->transformer->transform($createdCategory), 201);
     }
 
     #[Filter(by: 'tokens')]
@@ -151,10 +149,9 @@ class CategoriesController extends BaseApiController
         return $this->respondNoContent();
     }
 
-    #[Filter(by: 'tokens')]
     public function posts($id = null): ResponseInterface
     {
-        $category = $this->model->where('tenant_id', auth()->user()->tenant_id)->find($id);
+        $category = $this->model->find($id);
 
         if (!$category) {
             return $this->failNotFound("Category not found: $id");
@@ -162,11 +159,10 @@ class CategoriesController extends BaseApiController
 
         $posts = model('PostModel')
             ->where('category_id', $id)
-            ->where('tenant_id', auth()->user()->tenant_id)
             ->where('state', 'published')
             ->findAll();
 
-        return $this->respond((new PostTransformer())->transformMany($posts));
+        return $this->responseWith((new PostTransformer())->transformMany($posts));
     }
 
 }

--- a/tests/api/CategoriesApiTest.php
+++ b/tests/api/CategoriesApiTest.php
@@ -47,7 +47,7 @@ class CategoriesApiTest extends CIUnitTestCase
 
         $json = json_decode($result->getJSON());
         $this->assertObjectHasProperty('data', $json);
-        $this->assertIsArray($json->data);
+        $this->assertIsArray($json->data->items);
     }
 
     /**
@@ -146,7 +146,7 @@ class CategoriesApiTest extends CIUnitTestCase
             'Authorization' => 'Bearer ' . $this->token
         ])->delete("/api/v1/categories/{$categoryId}");
 
-        $result->assertStatus(200);
+        $result->assertStatus(204);
     }
 
     /**
@@ -161,7 +161,7 @@ class CategoriesApiTest extends CIUnitTestCase
         $result->assertStatus(200);
         $json = json_decode($result->getJSON());
         $this->assertObjectHasProperty('data', $json);
-        $this->assertIsArray($json->data);
+        $this->assertIsArray($json->data->items);
     }
 
     // Helper Methods


### PR DESCRIPTION
## Summary

`CategoriesApiTest` 5건 (1 error + 4 failures) 해결. 사전부채로 main CI에 누적되어 있던 실패를 정리.

### 변경 내용

- **Routes.php**: `/api/v1/categories` GET 3건(index, show, posts)을 `tokens` 그룹 밖으로 이동. `resource()`는 `only` 옵션으로 create/update/delete만 등록 (PostsController의 공개 GET 패턴과 정합)
- **CategoriesController.php**: index/show/posts에서 `#[Filter(by: 'tokens')]` 및 `auth()->user()->tenant_id` 의존 제거. 응답을 `responseWith`/`responseWithItem`으로 통일하여 envelope 일관성 확보
- **CategoriesApiTest.php**: `responseWith` 구조 반영(`data->items`), DELETE 응답 코드를 RFC 7231에 맞게 204로 보정

### 결과

```
OK (7 tests, 18 assertions)
```

## 결정 사항

- 공개 GET 엔드포인트 정책 채택 (이슈 #114 본문 의도 + 컨트롤러 docblock 의도 + 테스트 의도가 모두 일치)
- 멀티테넌시 격리는 PostsController와 동일하게 컨트롤러 레벨에서 처리하지 않는 패턴으로 통일

## 남은 작업 / 부채

- **테넌트 격리 누락**: Categories 공개 GET도 #99(`PostsController::show()` 테넌트 격리 누락)와 동일한 부채를 갖게 됨. #99 확장 또는 별도 이슈로 분리 필요
- **OpenAPI 스펙 갱신**: 공개 엔드포인트로의 정책 변경 반영 (#101 영역)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)