### PR TITLE
✨ feat: 댓글 트리(threaded) 응답 + 테스트/OpenAPI (#127)

### DIFF
--- a/app/Config/Comments.php
+++ b/app/Config/Comments.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+class Comments extends BaseConfig
+{
+    public int $maxDepth = 3;
+}

--- a/app/Controllers/Api/V1/CommentsController.php
+++ b/app/Controllers/Api/V1/CommentsController.php
@@ -34,28 +34,31 @@ class CommentsController extends BaseApiController
     {
         $rules = [
             'per_page' => 'permit_empty|integer|greater_than_equal_to[1]|less_than_equal_to[100]',
+            'page'     => 'permit_empty|integer|greater_than_equal_to[1]',
             'post_id'  => 'permit_empty|integer|is_natural_no_zero',
         ];
 
         $per_page = $this->request->getGet('per_page');
         $post_id = $this->request->getGet('post_id');
-        $data = compact('per_page', 'post_id');
+        $page = $this->request->getGet('page');
+
+        $data = compact('per_page', 'post_id', 'page');
 
         if (!$this->validateData($data, $rules)) {
             return $this->failValidationErrors($this->validator->getErrors());
         }
 
         $per_page = max(1, min(100, (int)$per_page ?: 10));
+        $page = max(1, (int)$page ?: 1);
 
-        $builder = $this->model->where('state', CommentState::APPROVED->value);
+        $items = $post_id
+            ? $this->model->findThreaded((int)$post_id, $per_page, $page)
+            : $this->model->where('state', CommentState::APPROVED->value)->paginate($per_page);
 
-        if ($post_id) {
-            $builder->where('post_id', $post_id);
-        }
-
-        $comments = $builder->paginate($per_page);
-
-        return $this->responseWith($this->transformer->transformMany($comments), $this->model->pager);
+        return $this->responseWith(
+            $this->transformer->transformMany($items),
+            $this->model->pager
+        );
     }
 
     public function show($id = null): ResponseInterface

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -4,7 +4,9 @@ namespace App\Controllers\Api\V1;
 
 use App\Entities\PostEntity;
 use App\Enums\UserRole;
+use App\Models\CommentModel;
 use App\Models\PostModel;
+use App\Transformers\CommentTransformer;
 use App\Transformers\PostTransformer;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Router\Attributes\Filter;
@@ -289,9 +291,35 @@ class PostsController extends BaseApiController
 
     public function comments($id = null): ResponseInterface
     {
-        // TODO: $comments = model('CommentModel')->where('post_id', $id)->findAll();
-        // return $this->respond((new CommentTransformer())->transformMany($comments));
-        return $this->respond([]);
+        $post = $this->model->find($id);
+
+        if (!$post || !$post->isPublished()) {
+            return $this->failNotFound('Post not found');
+        }
+
+        $rules = [
+            'per_page' => 'permit_empty|integer|greater_than_equal_to[1]|less_than_equal_to[100]',
+            'page'     => 'permit_empty|integer|greater_than_equal_to[1]',
+        ];
+
+        $per_page = $this->request->getGet('per_page');
+        $page = $this->request->getGet('page');
+
+        $data = compact('per_page', 'page');
+
+        if (!$this->validateData($data, $rules)) {
+            return $this->failValidationErrors($this->validator->getErrors());
+        }
+
+        $per_page = max(1, min(100, (int)$per_page ?: 10));
+        $page = max(1, (int)$page ?: 1);
+
+        $commentModel = model(CommentModel::class);
+        $transformer = new CommentTransformer();
+
+        $tree = $commentModel->findThreaded((int)$id, $per_page, $page);
+
+        return $this->responseWith($transformer->transformMany($tree), $commentModel->pager);
     }
 
     /**

--- a/app/Models/CommentModel.php
+++ b/app/Models/CommentModel.php
@@ -58,4 +58,52 @@ class CommentModel extends Model
             'state'     => CommentState::APPROVED->value,
         ];
     }
+
+    public function findThreaded(int $postId, int $perPage = 10, int $page = 1): array
+    {
+        $roots = [];
+        $childrenByParent = [];
+
+        $allComments = $this->where('post_id', $postId)
+            ->where('state', CommentState::APPROVED->value)
+            ->orderBy('created_at', 'asc')
+            ->findAll();
+
+        foreach ($allComments as $comment) {
+            if ($comment->parent_id === null) {
+                $roots[] = $comment;
+            } else {
+                $childrenByParent[$comment->parent_id][] = $comment;
+            }
+        }
+
+        $totalRoots = count($roots);
+
+        $pagedRoots = array_slice($roots, ($page - 1) * $perPage, $perPage);
+
+        $maxDepth = config('Comments')->maxDepth;
+
+        foreach ($pagedRoots as $root) {
+            $root->replies = $this->attachReplies($root->id, $childrenByParent, 2, $maxDepth);
+        }
+
+        $this->pager = service('pager')->store('default', $page, $perPage, $totalRoots);
+
+        return $pagedRoots;
+    }
+
+    private function attachReplies(int $parentId, array $childrenByParent, int $depth, int $maxDepth): array
+    {
+        if ($depth > $maxDepth) {
+            return [];
+        }
+
+        $children = $childrenByParent[$parentId] ?? [];
+
+        foreach ($children as $child) {
+            $child->replies = $this->attachReplies($child->id, $childrenByParent, $depth + 1, $maxDepth);
+        }
+
+        return $children;
+    }
 }

--- a/app/Transformers/CommentTransformer.php
+++ b/app/Transformers/CommentTransformer.php
@@ -16,9 +16,10 @@ class CommentTransformer extends BaseTransformer
             'user_id'    => $resource['user_id'],
             'parent_id'  => $resource['parent_id'] ?? null,
             'content'    => $resource['content'],
-            'state'     => $resource['state'] instanceof \BackedEnum
+            'state'      => $resource['state'] instanceof \BackedEnum
                 ? $resource['state']->value
                 : $resource['state'],
+            'replies'    => $this->transformMany($resource['replies'] ?? []),
             'created_at' => $resource['created_at'],
             'updated_at' => $resource['updated_at'],
         ];
@@ -26,12 +27,12 @@ class CommentTransformer extends BaseTransformer
 
     protected function getAllowedFields(): ?array
     {
-        return ['id', 'post_id', 'user_id', 'parent_id', 'content', 'state', 'created_at', 'updated_at'];
+        return ['id', 'post_id', 'user_id', 'parent_id', 'content', 'state', 'replies', 'created_at', 'updated_at'];
     }
 
     protected function getAllowedIncludes(): ?array
     {
-        // DB 구현 후 'author', 'replies' 추가 예정
+        // 'author' 추가 예정
         return [];
     }
 }

--- a/public/docs/openapi.yaml
+++ b/public/docs/openapi.yaml
@@ -356,7 +356,11 @@ paths:
       tags:
         - Posts
       summary: 포스트 댓글 목록
-      description: 특정 포스트의 댓글 목록을 조회합니다.
+      description: |
+        특정 포스트의 댓글 목록을 트리(threaded) 구조로 조회합니다.
+        루트 댓글 기준 페이지네이션이 적용되며, `replies` 필드에 자식 댓글이
+        재귀적으로 포함됩니다. `Config\Comments::$maxDepth`(기본 3)를 초과하는
+        깊이의 댓글은 빈 배열로 잘립니다.
       operationId: getPostComments
       parameters:
         - $ref: '#/components/parameters/IdParam'
@@ -373,9 +377,14 @@ paths:
                   - type: object
                     properties:
                       data:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Comment'
+                        type: object
+                        properties:
+                          items:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Comment'
+                          pagination:
+                            $ref: '#/components/schemas/Pagination'
 
   /posts/{id}/publish:
     post:
@@ -842,7 +851,12 @@ paths:
       tags:
         - Comments
       summary: 댓글 목록
-      description: 댓글 목록을 조회합니다.
+      description: |
+        댓글 목록을 조회합니다.
+
+        - `post_id` 쿼리가 주어지면 해당 포스트의 댓글을 **트리(threaded) 구조**로 반환합니다
+          (루트 댓글 기준 페이지네이션, `replies` 재귀 포함, `maxDepth` 초과 시 빈 배열로 절단).
+        - `post_id`가 없으면 전체 APPROVED 댓글을 **평면(flat) 구조**로 반환합니다 (`replies`는 빈 배열).
       operationId: getComments
       parameters:
         - $ref: '#/components/parameters/PageParam'
@@ -851,7 +865,7 @@ paths:
           in: query
           schema:
             type: integer
-          description: 포스트 ID로 필터링
+          description: 포스트 ID로 필터링 (지정 시 트리 응답)
       responses:
         '200':
           description: 댓글 목록 조회 성공
@@ -863,9 +877,14 @@ paths:
                   - type: object
                     properties:
                       data:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Comment'
+                        type: object
+                        properties:
+                          items:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Comment'
+                          pagination:
+                            $ref: '#/components/schemas/Pagination'
 
     post:
       tags:
@@ -2012,6 +2031,10 @@ components:
           $ref: '#/components/schemas/User'
         replies:
           type: array
+          description: |
+            대댓글 트리. 트리 응답(`/comments?post_id=...`, `/posts/{id}/comments`)에서만
+            채워지며, 평면 응답에서는 빈 배열입니다. `Config\Comments::$maxDepth`를
+            초과하는 깊이의 노드는 빈 배열로 절단됩니다.
           items:
             $ref: '#/components/schemas/Comment'
 

--- a/tests/api/CommentsApiTest.php
+++ b/tests/api/CommentsApiTest.php
@@ -4,6 +4,7 @@ namespace Tests\Api;
 
 use App\Database\Seeds\TestSeeder;
 use App\Entities\CommentEntity;
+use App\Entities\PostEntity;
 use App\Enums\CommentState;
 use App\Enums\PostState;
 use App\Models\CommentModel;
@@ -431,13 +432,17 @@ class CommentsApiTest extends CIUnitTestCase
     protected function createSimpleTree(int $postId): array
     {
         $fab = new Fabricator(CommentModel::class);
+
         $fab->setOverrides(['post_id' => $postId, 'parent_id' => null, 'state' => CommentState::APPROVED->value]);
+        /** @var CommentEntity $root */
         $root = $fab->create();
 
         $fab->setOverrides(['post_id' => $postId, 'parent_id' => $root->id, 'state' => CommentState::APPROVED->value]);
+        /** @var CommentEntity $child */
         $child = $fab->create();
 
         $fab->setOverrides(['post_id' => $postId, 'parent_id' => $child->id, 'state' => CommentState::APPROVED->value]);
+        /** @var CommentEntity $grandchild */
         $grandchild = $fab->create();
 
         return ['root' => $root, 'child' => $child, 'grandchild' => $grandchild];
@@ -451,6 +456,7 @@ class CommentsApiTest extends CIUnitTestCase
     protected function createDeepChain(int $postId, int $depth): array
     {
         $parentId = null;
+        /** @var CommentEntity[] $nodes */
         $nodes = [];
 
         $fab = new Fabricator(CommentModel::class);
@@ -458,9 +464,11 @@ class CommentsApiTest extends CIUnitTestCase
         for ($i = 0; $i < $depth; $i++) {
             $fab->setOverrides(['post_id' => $postId, 'parent_id' => $parentId, 'state' => CommentState::APPROVED->value]);
 
-            $nodes[] = $fab->create();
+            /** @var CommentEntity $node */
+            $node = $fab->create();
+            $nodes[] = $node;
 
-            $parentId = $nodes[$i]->id;
+            $parentId = $node->id;
         }
 
         return ['nodes' => $nodes];
@@ -475,11 +483,15 @@ class CommentsApiTest extends CIUnitTestCase
     {
         $fab = new Fabricator(CommentModel::class);
 
+        /** @var CommentEntity $approved */
         $approved = $fab->setOverrides(['post_id' => $postId, 'state' => CommentState::APPROVED->value])->create();
+        /** @var CommentEntity $pending */
         $pending = $fab->setOverrides(['post_id' => $postId, 'state' => CommentState::PENDING->value])->create();
 
+        /** @var PostEntity $otherPost */
         $otherPost = (new Fabricator(PostModel::class))->create();
 
+        /** @var CommentEntity $anotherPost */
         $anotherPost = $fab->setOverrides(['post_id' => $otherPost->id, 'state' => CommentState::APPROVED->value])->create();
 
         return ['approved' => $approved, 'pending' => $pending, 'another_post' => $anotherPost];

--- a/tests/api/CommentsApiTest.php
+++ b/tests/api/CommentsApiTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Api;
 
 use App\Database\Seeds\TestSeeder;
+use App\Entities\CommentEntity;
+use App\Enums\CommentState;
+use App\Enums\PostState;
 use App\Models\CommentModel;
 use App\Models\PostModel;
 use CodeIgniter\Shield\Entities\User;
@@ -37,9 +40,10 @@ class CommentsApiTest extends CIUnitTestCase
 
         $this->resetServices();
 
-        $post = (new Fabricator(PostModel::class))->create();
+        $fabricator = new Fabricator(PostModel::class);
+        $fabricator->setOverrides(['state' => PostState::Published->value]);
+        $post = $fabricator->create();
         $this->postId = $post->id;
-
     }
 
     /**
@@ -75,6 +79,116 @@ class CommentsApiTest extends CIUnitTestCase
         foreach ($json->data->items as $comment) {
             $this->assertEquals($this->postId, $comment->post_id);
         }
+    }
+
+    /**
+     * @test
+     * GET /api/v1/comments?post_id={id}
+     * 댓글이 트리 구조로 응답되어야 함 (replies 재귀 직렬화)
+     */
+    public function test_get_comments_returns_threaded_tree_when_post_id_given(): void
+    {
+        $tree = $this->createSimpleTree($this->postId);
+
+        $result = $this->get("/api/v1/comments?post_id={$this->postId}");
+
+        $result->assertStatus(200);
+
+        $json = json_decode($result->getJSON());
+
+        $this->assertCount(1, $json->data->items);
+        $this->assertEquals($tree['root']->id, $json->data->items[0]->id);
+        $this->assertIsArray($json->data->items[0]->replies);
+        $this->assertCount(1, $json->data->items[0]->replies);
+        $this->assertEquals($tree['child']->id, $json->data->items[0]->replies[0]->id);
+        $this->assertIsArray($json->data->items[0]->replies[0]->replies);
+        $this->assertEquals($tree['grandchild']->id, $json->data->items[0]->replies[0]->replies[0]->id);
+        $this->assertEmpty($json->data->items[0]->replies[0]->replies[0]->replies);
+        $this->assertCount(1, $json->data->items[0]->replies[0]->replies);
+    }
+
+    /**
+     * @test
+     * GET /api/v1/comments?post_id={id}
+     *
+     * 댓글의 트리 깊이는 설정값(config/Comments->maxDepth)을 초과하면 자식 댓글은 응답에 포함되지 않음
+     */
+    public function test_threaded_comments_respect_max_depth(): void
+    {
+        config('Comments')->maxDepth = 3;
+
+        $chain = $this->createDeepChain($this->postId, 5);
+
+        $result = $this->get("/api/v1/comments?post_id={$this->postId}");
+
+        $result->assertStatus(200);
+
+        $json = json_decode($result->getJSON());
+
+        // 1단계 — 루트
+        $this->assertCount(1, $json->data->items);
+        $this->assertEquals($chain['nodes'][0]->id, $json->data->items[0]->id);
+
+        // 2단계 — 자식 (응답에 있어야 함)
+        $this->assertCount(1, $json->data->items[0]->replies);
+        $this->assertEquals($chain['nodes'][1]->id, $json->data->items[0]->replies[0]->id);
+
+        // 3단계 — 손자 (응답에 있어야 함, 여기까지는 OK)
+        $this->assertCount(1, $json->data->items[0]->replies[0]->replies);
+        $this->assertEquals($chain['nodes'][2]->id, $json->data->items[0]->replies[0]->replies[0]->id);
+
+        // 4단계 — 증손자 ❌ (잘려야 함)
+        $this->assertEmpty($json->data->items[0]->replies[0]->replies[0]->replies);
+    }
+
+    /**
+     * @test
+     * GET /api/v1/posts/{id}/comments
+     * 게시글의 댓글 조회시에도 댓글 트리 구조를 반환
+     */
+    public function test_posts_comments_returns_threaded_tree(): void
+    {
+        $tree = $this->createSimpleTree($this->postId);
+
+        $result = $this->get("/api/v1/posts/{$this->postId}/comments");
+
+        $result->assertStatus(200);
+
+        $json = json_decode($result->getJSON());
+
+        $this->assertCount(1, $json->data->items);
+        $this->assertEquals($tree['root']->id, $json->data->items[0]->id);
+        $this->assertIsArray($json->data->items[0]->replies);
+        $this->assertCount(1, $json->data->items[0]->replies);
+        $this->assertEquals($tree['child']->id, $json->data->items[0]->replies[0]->id);
+        $this->assertIsArray($json->data->items[0]->replies[0]->replies);
+        $this->assertEquals($tree['grandchild']->id, $json->data->items[0]->replies[0]->replies[0]->id);
+        $this->assertEmpty($json->data->items[0]->replies[0]->replies[0]->replies);
+        $this->assertCount(1, $json->data->items[0]->replies[0]->replies);
+    }
+
+
+    /**
+     * @test
+     * GET /api/v1/comments?post_id={id}
+     * 다른 게시글의 뎃글이 응답에 섞이지 않음, pending 상태의 댓글은 응답에 포함되지 않음
+     */
+    public function test_threaded_response_excludes_pending_and_other_post(): void
+    {
+        $scenario = $this->createMixedScenario($this->postId);
+
+        $result = $this->get("/api/v1/comments?post_id={$this->postId}");
+
+        $result->assertStatus(200);
+
+        $json = json_decode($result->getJSON());
+
+        $ids = array_column($json->data->items, 'id');
+
+        $this->assertCount(1, $json->data->items);
+        $this->assertContains($scenario['approved']->id, $ids);
+        $this->assertNotContains($scenario['pending']->id, $ids);
+        $this->assertNotContains($scenario['another_post']->id, $ids);
     }
 
     /**
@@ -215,9 +329,7 @@ class CommentsApiTest extends CIUnitTestCase
         $commentId = $this->createTestComment();
 
         $headers = ['Authorization' => 'Bearer ' . $this->token];
-        $moderateData = [
-            'state' => 'approved'
-        ];
+        $moderateData = ['state' => CommentState::APPROVED->value];
 
         $result = $this->withHeaders($headers)
             ->withBodyFormat('json')
@@ -239,9 +351,10 @@ class CommentsApiTest extends CIUnitTestCase
 
         $result = $this->withHeaders($headers)
             ->withBodyFormat('json')
-            ->post('/api/v1/comments/1/moderate', [
-                'state' => 'approved'
-            ]);
+            ->post(
+                '/api/v1/comments/1/moderate',
+                ['state' => CommentState::APPROVED->value]
+            );
 
         $result->assertStatus(403);
     }
@@ -307,5 +420,68 @@ class CommentsApiTest extends CIUnitTestCase
         $this->assertNotNull($json->data->id ?? null, 'createTestComment failed: ' . $result->getJSON());
 
         return (int)$json->data->id;
+    }
+
+
+    /**
+     * 단순 3단 트리
+     *
+     * @return array{root: CommentEntity, child: CommentEntity, grandchild: CommentEntity}
+     */
+    protected function createSimpleTree(int $postId): array
+    {
+        $fab = new Fabricator(CommentModel::class);
+        $fab->setOverrides(['post_id' => $postId, 'parent_id' => null, 'state' => CommentState::APPROVED->value]);
+        $root = $fab->create();
+
+        $fab->setOverrides(['post_id' => $postId, 'parent_id' => $root->id, 'state' => CommentState::APPROVED->value]);
+        $child = $fab->create();
+
+        $fab->setOverrides(['post_id' => $postId, 'parent_id' => $child->id, 'state' => CommentState::APPROVED->value]);
+        $grandchild = $fab->create();
+
+        return ['root' => $root, 'child' => $child, 'grandchild' => $grandchild];
+    }
+
+    /**
+     * 깊은 사슬
+     *
+     * @return array ['nodes' => CommentEntity[]]
+     */
+    protected function createDeepChain(int $postId, int $depth): array
+    {
+        $parentId = null;
+        $nodes = [];
+
+        $fab = new Fabricator(CommentModel::class);
+
+        for ($i = 0; $i < $depth; $i++) {
+            $fab->setOverrides(['post_id' => $postId, 'parent_id' => $parentId, 'state' => CommentState::APPROVED->value]);
+
+            $nodes[] = $fab->create();
+
+            $parentId = $nodes[$i]->id;
+        }
+
+        return ['nodes' => $nodes];
+    }
+
+    /**
+     * 혼합 시나리오
+     *
+     * @return array{approved: CommentEntity, pending: CommentEntity, another_post: CommentEntity}
+     */
+    protected function createMixedScenario(int $postId): array
+    {
+        $fab = new Fabricator(CommentModel::class);
+
+        $approved = $fab->setOverrides(['post_id' => $postId, 'state' => CommentState::APPROVED->value])->create();
+        $pending = $fab->setOverrides(['post_id' => $postId, 'state' => CommentState::PENDING->value])->create();
+
+        $otherPost = (new Fabricator(PostModel::class))->create();
+
+        $anotherPost = $fab->setOverrides(['post_id' => $otherPost->id, 'state' => CommentState::APPROVED->value])->create();
+
+        return ['approved' => $approved, 'pending' => $pending, 'another_post' => $anotherPost];
     }
 }


### PR DESCRIPTION
## Summary
- 댓글 목록 응답을 트리(threaded) 구조로 반환 (`/comments?post_id=...`, `/posts/{id}/comments`)
- `Config\Comments::$maxDepth` (기본 3)로 트리 깊이 절단, 페이지네이션은 루트 댓글 기준
- `CommentsApiTest`에 트리 케이스 4개 + 픽스처 헬퍼 3종 추가
- OpenAPI 스펙(`Comment.replies`, 두 GET 엔드포인트) 갱신

closes #127

## 결정사항
- **응답 형식**: nested `replies` 배열 (Disqus 스타일). 평면+depth 표시는 클라이언트 트리 재구성 비용을 그대로 두는 셈이라 제외
- **maxDepth=3**: 댓글 UX상 3단 이상은 가독성 저하 — Config로 빼두어 추후 조정 가능
- **단일 SELECT + PHP 트리 빌드**: N+1 회피, 페이지네이션은 `service('pager')->store(...)`로 수동 처리
- **트리/평면 분기**: `post_id` 쿼리 유무로 결정. `post_id` 없는 전체 조회는 평면 유지 (트리는 post 단위에서만 의미)
- **픽스처 헬퍼 3개로 분리**: 케이스마다 트리 모양이 달라 인자 폭탄 헬퍼 1개보다 의도가 명확한 3개 분리가 가독성에 이득

## 테스트
- 케이스 #1: 기본 트리 응답 (replies 재귀 직렬화)
- 케이스 #2: maxDepth 절단 (depth 5 사슬 → 손자에서 잘림)
- 케이스 #3: PostsController 경로 (`/posts/{id}/comments`도 트리)
- 케이스 #4: 보안 (PENDING/다른 post 댓글 격리)
- 전체 회귀: phpunit 191 tests / 462 assertions 통과

## 부채 / 후속
- `CommentsApiTest::setUp()`에서 발견한 flaky 원인은 `PostModel::fake()`의 `state => randomElement(['draft', 'published'])`. 이번 PR은 setUp에서 `state` override로 우회했지만, **다른 ApiTest 픽스처도 동일한 비결정성에 노출**될 수 있어 별도 점검 필요 (별도 이슈 권장)
- `CommentTransformer::getAllowedIncludes()`에 `'author'` 포함은 추후 작업 (현 코드에 TODO 주석)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 댓글 스레드 구조 지원 - 사용자가 답글에 대한 답글을 달 수 있는 중첩 댓글 기능을 추가했습니다.
* 트리 형식 응답 - API가 댓글과 그 답글들을 계층적 구조로 반환합니다.
* 깊이 설정 가능 - 댓글 중첩 깊이를 제한할 수 있도록 설정했습니다.
* 페이지네이션 개선 - 트리 구조에서도 효율적인 페이지네이션을 지원합니다.

## 문서
* API 문서 업데이트 - 스레드된 댓글 응답 구조 설명을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->