### PR TITLE
⚡ perf: comments.parent_id 인덱스 + self-ref FK 추가 (#124)

### DIFF
--- a/app/Database/Migrations/2026-03-06-091500_CreateCommentsTable.php
+++ b/app/Database/Migrations/2026-03-06-091500_CreateCommentsTable.php
@@ -21,8 +21,10 @@ class CreateCommentsTable extends Migration
         ]);
 
         $this->forge->addPrimaryKey('id');
+        $this->forge->addKey('parent_id');
         $this->forge->addForeignKey('post_id', 'posts', 'id', 'NO ACTION', 'CASCADE');
         $this->forge->addForeignKey('user_id', 'users', 'id', 'NO ACTION', 'CASCADE');
+        $this->forge->addForeignKey('parent_id', 'comments', 'id', 'CASCADE', 'CASCADE');
         $this->forge->createTable('comments');
     }
 
@@ -30,6 +32,7 @@ class CreateCommentsTable extends Migration
     {
         $this->forge->dropForeignKey('comments', 'comments_post_id_foreign');
         $this->forge->dropForeignKey('comments', 'comments_user_id_foreign');
+        $this->forge->dropForeignKey('comments', 'comments_parent_id_foreign');
         $this->forge->dropTable('comments', true);
     }
 }


### PR DESCRIPTION
## Summary
- `comments.parent_id`에 일반 인덱스 추가 — 대댓글 조회 시 인덱스 시크 보장
- self-reference FK `parent_id → comments.id` 추가, ON DELETE/UPDATE `CASCADE`
- 서비스 배포 전 단계라 신규 마이그레이션 대신 기존 `CreateCommentsTable` 직접 수정

## 결정
- **ON DELETE = CASCADE**: 평상시 soft delete로 FK가 발동하지 않음. hard delete/purge 경로에서 스레드 통째 정리 의도. 다른 FK(`post_id` cascade)와도 일관됨
- **명시적 `addKey('parent_id')`**: MySQL FK 자동 인덱스에 의존하지 않고 인덱스명 통제 + SQLite/기타 DB 호환성 확보
- **기존 마이그레이션 수정**: 배포 전 히스토리 정합성 우선

## 검증
- `php spark migrate:rollback --all && php spark migrate` 왕복 OK
- `EXPLAIN QUERY PLAN SELECT * FROM comments WHERE parent_id = ?`:
  - `SEARCH comments USING INDEX comments_parent_id (parent_id=?)`

## 남은 작업
- `#123` comments.state ENUM 전환 (별개 이슈)
- `#125` 모더레이션 테스트 강화 (별개 이슈)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글에 대한 답글(중첩 댓글) 기능을 지원하도록 데이터베이스 구조를 개선했습니다. 이제 사용자가 다른 댓글에 직접 답글을 달 수 있으며, 관련 데이터는 자동으로 관리됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/129)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->