### PR TITLE
♻️ refactor: state 검증을 EnumRules::enumValue로 통일 (#126)

### DIFF
--- a/app/Controllers/Api/V1/CommentsController.php
+++ b/app/Controllers/Api/V1/CommentsController.php
@@ -227,8 +227,7 @@ class CommentsController extends BaseApiController
     #[Filter(by: 'apipermission', having: ['comments.manage'])]
     public function moderate($id = null): ResponseInterface
     {
-        $state = implode(',', array_column(CommentState::cases(), 'value'));
-        $rules = ['state' => "required|in_list[{$state}]"];
+        $rules = ['state' => 'required|enumValue[' . CommentState::class . ']'];
 
         $comment = $this->model->find($id);
 

--- a/app/Models/CommentModel.php
+++ b/app/Models/CommentModel.php
@@ -31,19 +31,11 @@ class CommentModel extends Model
         'user_id'   => 'required',
         'parent_id' => 'permit_empty|integer|is_natural_no_zero',
         'content'   => 'required|min_length[1]',
+        'state'     => 'required|enumValue[' . CommentState::class . ']',
     ];
     protected $validationMessages = [];
     protected $skipValidation = false;
     protected $cleanValidationRules = true;
-
-    public function __construct()
-    {
-        parent::__construct();
-
-        $this->validationRules['state'] = 'required|in_list['
-            . implode(',', array_column(CommentState::cases(), 'value'))
-            . ']';
-    }
 
     public function fake(Generator &$faker): array
     {


### PR DESCRIPTION
## Summary

- `CommentsController::moderate`와 `CommentModel`에서 매번 조립하던 `array_column + implode + in_list` 패턴을 `enumValue[CommentState::class]` 한 줄로 교체
- `App\Validation\EnumRules`는 이미 `Config\Validation`에 등록되어 있었으나 실 사용처가 없던 상태 → 첫 사용처 확보
- `CommentModel::__construct` 제거: 생성자가 오직 동적 룰 조립용이었으므로 제거하고 `$validationRules` 정적 배열로 이동

## 결정 사항

- **#123 ENUM 컬럼 전환은 wontfix로 close.** SQLite/MySQL 호환성 차이, 새 state 추가 시 마이그레이션 부담, application enum과의 이중 source of truth 위험 때문. `CommentState` enum 하나를 단일 source of truth로 두고 application 레벨에서 검증하는 방향을 채택.
- 룰 문자열은 홑따옴표 + `::class` 상수 표기 (`'required|enumValue[' . CommentState::class . ']'`) — FQCN 이스케이프 안전 + IDE 리팩토링 추적성.

## 남은 작업

- #125 — CommentsApiTest 모더레이션 검증 강화 (응답 body / DB state 검증 추가, state 전환 케이스 추가)
- (선택) `CommentEntity::$casts`의 `'?enum[App\Enums\CommentState]'` FQCN 표기도 `::class` 통일 — nitpick이라 별도 이슈 분리 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 댓글 상태 필드의 유효성 검사 로직을 개선했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/130)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->