### PR TITLE
✅ test: 댓글 모더레이션 검증 강화 (#125)

### DIFF
--- a/tests/api/CommentsApiTest.php
+++ b/tests/api/CommentsApiTest.php
@@ -14,6 +14,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\Fabricator;
 use CodeIgniter\Test\FeatureTestTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -34,6 +35,15 @@ class CommentsApiTest extends CIUnitTestCase
     protected $migrate = true;
     protected $namespace = null;
     protected $refresh = true;
+
+    /**
+     * @return string[]
+     */
+    protected function getHeaders(): array
+    {
+        $headers = ['Authorization' => 'Bearer ' . $this->token];
+        return $headers;
+    }
 
     protected function setUp(): void
     {
@@ -201,7 +211,7 @@ class CommentsApiTest extends CIUnitTestCase
     {
         $this->loginAsUser();
 
-        $headers = ['Authorization' => 'Bearer ' . $this->token];
+        $headers = $this->getHeaders();
         $commentData = [
             'post_id' => $this->postId,
             'content' => '테스트 댓글입니다.'
@@ -261,7 +271,7 @@ class CommentsApiTest extends CIUnitTestCase
         $this->loginAsUser();
 
         $commentId = $this->createTestComment();
-        $headers = ['Authorization' => 'Bearer ' . $this->token];
+        $headers = $this->getHeaders();
         $updateData = [
             'content' => '수정된 댓글 내용'
         ];
@@ -285,7 +295,7 @@ class CommentsApiTest extends CIUnitTestCase
         $this->loginAsUser();
 
         $commentId = $this->createTestComment();
-        $headers = ['Authorization' => 'Bearer ' . $this->token];
+        $headers = $this->getHeaders();
 
         $result = $this->withHeaders($headers)->delete("/api/v1/comments/{$commentId}");
 
@@ -301,7 +311,7 @@ class CommentsApiTest extends CIUnitTestCase
     {
         $this->loginAsUser();
 
-        $headers = ['Authorization' => 'Bearer ' . $this->token];
+        $headers = $this->getHeaders();
         $replyData = [
             'content' => '대댓글입니다.'
         ];
@@ -323,20 +333,55 @@ class CommentsApiTest extends CIUnitTestCase
      * POST /api/v1/comments/{id}/moderate
      * 댓글 모더레이션 (Moderator 이상 권한 필요)
      */
-    public function test_moderate_comment_with_moderator_role(): void
+    #[DataProvider('moderationStateProvider')]
+    public function test_moderate_comment_transitions_state(string $targetState): void
     {
         $this->loginAsModerator();
 
         $commentId = $this->createTestComment();
 
-        $headers = ['Authorization' => 'Bearer ' . $this->token];
-        $moderateData = ['state' => CommentState::APPROVED->value];
+        $headers = $this->getHeaders();
+        $moderateData = ['state' => $targetState];
 
         $result = $this->withHeaders($headers)
             ->withBodyFormat('json')
             ->post("/api/v1/comments/{$commentId}/moderate", $moderateData);
 
         $result->assertStatus(200);
+        $result->assertJSONFragment(['status' => 'success']);
+
+        $json = json_decode($result->getJSON());
+        $this->assertEquals($targetState, $json->data->state);
+        $this->seeInDatabase('comments', ['id' => $commentId, 'state' => $targetState]);
+    }
+
+    /**
+     * @test
+     * POST /api/v1/comments/{id}/moderate
+     * 댓글 모더레이션 상태가 유효하지 않을 경우 예외 처리
+     */
+    public function test_moderate_comment_rejects_invalid_state(): void
+    {
+        $this->loginAsModerator();
+
+        $commentId = $this->createTestComment();
+        $headers = $this->getHeaders();
+
+        $result = $this->withHeaders($headers)
+            ->withBodyFormat('json')
+            ->post("/api/v1/comments/{$commentId}/moderate", ['state' => 'invalid_state']);
+
+        $result->assertStatus(422);
+
+        $this->seeInDatabase('comments', ['id' => $commentId, 'state' => CommentState::PENDING->value]);
+    }
+
+    public static function moderationStateProvider(): array
+    {
+        return [
+            'approved' => [CommentState::APPROVED->value],
+            'rejected' => [CommentState::REJECTED->value],
+        ];
     }
 
     /**
@@ -348,7 +393,7 @@ class CommentsApiTest extends CIUnitTestCase
     {
         $this->loginAsUser();
 
-        $headers = ['Authorization' => 'Bearer ' . $this->token];
+        $headers = $this->getHeaders();
 
         $result = $this->withHeaders($headers)
             ->withBodyFormat('json')

--- a/tests/api/CommentsApiTest.php
+++ b/tests/api/CommentsApiTest.php
@@ -453,9 +453,8 @@ class CommentsApiTest extends CIUnitTestCase
 
     protected function createTestComment(): int
     {
-        $result = $this->withHeaders([
-            'Authorization' => 'Bearer ' . $this->token
-        ])->withBodyFormat('json')
+        $result = $this->withHeaders($this->getHeaders())
+            ->withBodyFormat('json')
             ->post('/api/v1/comments', [
                 'post_id' => $this->postId,
                 'content' => '테스트 댓글'


### PR DESCRIPTION
## Summary

- `test_moderate_comment_with_moderator_role` → `test_moderate_comment_transitions_state` 개명 + **DataProvider 도입**으로 `approved`/`rejected` 두 전환 케이스 동시 검증
- `assertStatus(200)`만 보던 검증을 **응답 body** (`json.data.state`)와 **DB state** (`seeInDatabase`)까지 확장
- 새 negative 테스트 `test_moderate_comment_rejects_invalid_state`: invalid state → 422 + DB state가 초기값(`pending`) 유지 검증. #126 `enumValue` 룰 회귀 가드 역할
- 부수 cleanup: `getHeaders()` 헬퍼로 Bearer 토큰 헤더 조립 일원화

## 결정 사항

- **DataProvider 패턴 채택**: state 전환별로 동작이 동일(룰 통과 → update → transformer 반환)하므로 DRY 원칙에 부합. 새 state(예: `flagged`) 추가 시 provider 한 줄로 확장 가능
- **`pending` 케이스 제외**: `createTestComment()`가 만든 댓글의 초기 state가 `pending`이라 "pending → pending"은 transition이 아닌 no-op. 실제 전환을 검증하는 의도와 어긋남
- **invalid state 검증의 강화**: `seeInDatabase`로 state가 `pending` 그대로임을 확인 → update가 일어나지 않았음을 강하게 보장

## 남은 작업

- 테스트 실행 속도 (16개 / ~15.5초) 개선은 별도 이슈로 분리 예정. 후보: `paratest` 도입 또는 `\$refresh` 전략 재검토
- (선택) `getHeaders()` 같은 공통 헬퍼를 다른 ApiTest 클래스에서도 활용 가능 → 별도 이슈 분리 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 댓글 API 테스트 구조를 개선하여 인증 헤더 처리를 표준화하고 중재 상태 전환에 대한 테스트 커버리지를 강화했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/131)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->