### PR TITLE
🔒 fix: show()/comments() 메서드에 테넌트 격리 적용 (#99)

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -4,6 +4,7 @@ namespace Config;
 
 use App\Filters\ApiGroupFilter;
 use App\Filters\ApiPermissionFilter;
+use App\Filters\ApiTenantFilter;
 use App\Filters\TenantFilter;
 use CodeIgniter\Config\Filters as BaseFilters;
 use CodeIgniter\Filters\Cors;
@@ -39,7 +40,8 @@ class Filters extends BaseFilters
         'performance'   => PerformanceMetrics::class,
         'tenant'        => TenantFilter::class,
         'apigroup'      => ApiGroupFilter::class,
-        'apipermission' => ApiPermissionFilter::class
+        'apipermission' => ApiPermissionFilter::class,
+        'apitenant'     => ApiTenantFilter::class,
     ];
 
     /**

--- a/app/Controllers/Api/V1/CategoriesController.php
+++ b/app/Controllers/Api/V1/CategoriesController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controllers\Api\V1;
 
+use App\Enums\PostState;
 use App\Models\CategoryModel;
 use App\Transformers\CategoryTransformer;
 use App\Transformers\PostTransformer;
@@ -153,9 +154,14 @@ class CategoriesController extends BaseApiController
         return $this->respondNoContent();
     }
 
+    #[Filter(by: 'apitenant')]
     public function posts($id = null): ResponseInterface
     {
-        $category = $this->model->find($id);
+        $tenantId = service('tenant')->getId();
+
+        $category = $this->model
+            ->where('tenant_id', $tenantId)
+            ->find($id);
 
         if (!$category) {
             return $this->failNotFound("Category not found: $id");
@@ -163,7 +169,8 @@ class CategoriesController extends BaseApiController
 
         $posts = model('PostModel')
             ->where('category_id', $id)
-            ->where('state', 'published')
+            ->where('tenant_id', $tenantId)
+            ->where('state', PostState::PUBLISHED->value)
             ->findAll();
 
         return $this->responseWith((new PostTransformer())->transformMany($posts));

--- a/app/Controllers/Api/V1/CategoriesController.php
+++ b/app/Controllers/Api/V1/CategoriesController.php
@@ -9,7 +9,6 @@ use App\Transformers\CategoryTransformer;
 use App\Transformers\PostTransformer;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\HTTP\ResponseInterface;
-use CodeIgniter\Router\Attributes\Cache;
 use CodeIgniter\Router\Attributes\Filter;
 
 /**
@@ -40,9 +39,14 @@ class CategoriesController extends BaseApiController
         return $this->responseWith($this->transformer->transformMany($categories));
     }
 
+    #[Filter(by: 'apitenant')]
     public function show($id = null): ResponseInterface
     {
-        $category = $this->model->find($id);
+        $tenantId = service('tenant')->getId();
+        
+        $category = $this->model
+            ->where('tenant_id', $tenantId)
+            ->find($id);
 
         if ($category === null) {
             return $this->failNotFound();

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -42,6 +42,7 @@ class PostsController extends BaseApiController
      * @see docs/openapi.yaml GET /posts
      * @see docs/openapi.yaml#PerPageParam, PaginationMeta
      */
+    #[Filter(by: 'apitenant')]
     public function index(): ResponseInterface
     {
         $rules = [
@@ -58,6 +59,8 @@ class PostsController extends BaseApiController
         if (!$this->validateData($data, $rules)) {
             return $this->failValidationErrors($this->validator->getErrors());
         }
+
+        $this->model->where('tenant_id', service('tenant')->getId());
 
         if ($search) {
             $this->model->search($search);

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -3,6 +3,7 @@
 namespace App\Controllers\Api\V1;
 
 use App\Entities\PostEntity;
+use App\Enums\PostState;
 use App\Enums\UserRole;
 use App\Models\CommentModel;
 use App\Models\PostModel;
@@ -67,7 +68,7 @@ class PostsController extends BaseApiController
         }
 
         // 공개 설정한 게시글만 조회
-        $this->model->where('state', 'published');
+        $this->model->where('state', PostState::PUBLISHED->value);
 
         $per_page = (int)$per_page ?: 10;
 
@@ -80,9 +81,15 @@ class PostsController extends BaseApiController
      * 게시글 조회
      *
      */
+    #[Filter(by: 'apitenant')]
     public function show($id = null): ResponseInterface
     {
-        $post = $this->model->find($id);
+        $tenantId = service('tenant')->getId();
+
+        $post = $this->model
+            ->where('tenant_id', $tenantId)
+            ->where('state', PostState::PUBLISHED->value)
+            ->find($id);
 
         if (!$post) {
             return $this->failNotFound();
@@ -289,11 +296,17 @@ class PostsController extends BaseApiController
         return $this->responseWithMessage('Post unpublished successfully');
     }
 
+    #[Filter(by: 'apitenant')]
     public function comments($id = null): ResponseInterface
     {
-        $post = $this->model->find($id);
+        $tenantId = service('tenant')->getId();
 
-        if (!$post || !$post->isPublished()) {
+        $post = $this->model
+            ->where('tenant_id', $tenantId)
+            ->where('state', PostState::PUBLISHED->value)
+            ->find($id);
+
+        if (!$post) {
             return $this->failNotFound('Post not found');
         }
 

--- a/app/Entities/PostEntity.php
+++ b/app/Entities/PostEntity.php
@@ -16,12 +16,12 @@ class PostEntity extends Entity
 
     public function isPublished(): bool
     {
-        return $this->state === PostState::Published;
+        return $this->state === PostState::PUBLISHED;
     }
 
     public function isDraft(): bool
     {
-        return $this->state === PostState::Draft;
+        return $this->state === PostState::DRAFT;
     }
 
     public function isOwnedBy(?int $userId): bool

--- a/app/Enums/PostState.php
+++ b/app/Enums/PostState.php
@@ -4,21 +4,21 @@ namespace App\Enums;
 
 enum PostState: string
 {
-    case Draft     = 'draft';
-    case Published = 'published';
-    case Archived  = 'archived';
+    case DRAFT     = 'draft';
+    case PUBLISHED = 'published';
+    case ARCHIVED  = 'archived';
 
     public function label(): string
     {
         return match($this) {
-            PostState::Draft     => '임시저장',
-            PostState::Published => '게시됨',
-            PostState::Archived  => '보관됨',
+            PostState::DRAFT     => '임시저장',
+            PostState::PUBLISHED => '게시됨',
+            PostState::ARCHIVED  => '보관됨',
         };
     }
 
     public function isPublic(): bool
     {
-        return $this === PostState::Published;
+        return $this === PostState::PUBLISHED;
     }
 }

--- a/app/Filters/ApiTenantFilter.php
+++ b/app/Filters/ApiTenantFilter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filters;
+
+use CodeIgniter\Filters\FilterInterface;
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+
+class ApiTenantFilter implements FilterInterface
+{
+    public function before(RequestInterface $request, $arguments = null)
+    {
+        $slug = $request->getHeaderLine('X-Tenant-Slug');
+
+        if (!$slug) {
+            return response()
+                ->setStatusCode(400)
+                ->setJSON([
+                    'code'    => 400,
+                    'status'  => 'error',
+                    'message' => 'X-Tenant-Slug header is required'
+                ]);
+        }
+
+        $model = model('TenantModel');
+        $tenant = $model->where('subdomain', $slug)->first();
+
+        if (!$tenant) {
+            return response()
+                ->setStatusCode(404)
+                ->setJSON([
+                    'code'    => 404,
+                    'status'  => 'error',
+                    'message' => 'Tenant not found'
+                ]);
+        }
+
+        service('tenant')->setTenant($tenant);
+        return null;
+    }
+
+    public function after(RequestInterface $request, ResponseInterface $response, $arguments = null): void
+    {
+        //
+    }
+}

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -77,7 +77,7 @@ class PostModel extends Model
             'state'       => $faker->randomElement(['draft', 'published']),
             'category_id' => 1,
             'writer_id'   => 1,
-            'tenant_id'   => 1,
+            'tenant_id'   => service('tenant')->getId() ?? 1,
         ];
     }
 

--- a/tests/api/CategoriesApiTest.php
+++ b/tests/api/CategoriesApiTest.php
@@ -178,7 +178,8 @@ class CategoriesApiTest extends CIUnitTestCase
      */
     public function test_get_category_posts(): void
     {
-        $result = $this->get('/api/v1/categories/1/posts');
+        $result = $this->withHeaders($this->getHeaders())
+            ->get("/api/v1/categories/{$this->category->id}/posts");
 
         $result->assertStatus(200);
         $json = json_decode($result->getJSON());
@@ -192,7 +193,7 @@ class CategoriesApiTest extends CIUnitTestCase
      */
     public function test_show_category_fails_without_tenant_header(): void
     {
-        $this->get('/api/v1/categories/1')->assertStatus(400);
+        $this->get("/api/v1/categories/{$this->category->id}")->assertStatus(400);
     }
 
     /**
@@ -202,10 +203,14 @@ class CategoriesApiTest extends CIUnitTestCase
     public function test_show_category_fails_with_invalid_tenant_slug(): void
     {
         $this->withHeaders(['X-Tenant-Slug' => 'nonexistent'])
-            ->get('/api/v1/categories/1')
+            ->get("/api/v1/categories/{$this->category->id}")
             ->assertStatus(404);
     }
 
+    /**
+     * @test
+     * GET /api/v1/categories/{id}
+     */
     public function test_show_category_isolates_other_tenant(): void
     {
         $otherTenantId = $this->createOtherTenant();
@@ -224,13 +229,11 @@ class CategoriesApiTest extends CIUnitTestCase
     // Helper Methods
     private function createOtherTenant(): int
     {
-        $this->db->table('tenants')
-            ->insert([
-                'subdomain' => 'other-tenant',
-                'name'      => 'other',
-            ]);
+        $tenant = (new Fabricator(TenantModel::class))
+            ->setOverrides(['subdomain' => 'other-tenant-' . uniqid()])
+            ->create();
 
-        return $this->db->insertID();
+        return $tenant->id;
     }
 
     protected function getHeaders(): array

--- a/tests/api/CategoriesApiTest.php
+++ b/tests/api/CategoriesApiTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Api;
 
 use App\Database\Seeds\TestSeeder;
+use App\Models\CategoryModel;
+use App\Models\TenantModel;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\Fabricator;
 use CodeIgniter\Test\FeatureTestTrait;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -25,12 +28,27 @@ class CategoriesApiTest extends CIUnitTestCase
     protected $migrate = true;
     protected $namespace = null;
     protected $refresh = true;
+    protected $tenant;
+    protected $category;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->resetServices();
+
+        $this->tenant = (new Fabricator(TenantModel::class))
+            ->setOverrides(['subdomain' => 'test-tenant-' . uniqid()])
+            ->create();
+
+        $this->category = (new Fabricator(CategoryModel::class))
+            ->setOverrides(['tenant_id' => $this->tenant->id])
+            ->create();
+
+        // 시드 admin user의 tenant_id를 새 tenant로 동기화
+        $userModel = auth()->getProvider();
+        $admin = $userModel->findByCredentials(['email' => 'admin@example.com']);
+        $userModel->update($admin->id, ['tenant_id' => $this->tenant->id]);
     }
 
     /**
@@ -65,9 +83,10 @@ class CategoriesApiTest extends CIUnitTestCase
             'description' => '카테고리 설명'
         ];
 
-        $result = $this->withHeaders([
-            'Authorization' => 'Bearer ' . $this->token
-        ])->withBodyFormat('json')
+        $headers = $this->getHeaders();
+
+        $result = $this->withHeaders($headers)
+            ->withBodyFormat('json')
             ->post('/api/v1/categories', $categoryData);
 
         $result->assertStatus(201);
@@ -98,12 +117,13 @@ class CategoriesApiTest extends CIUnitTestCase
      */
     public function test_get_category_by_id(): void
     {
-        $result = $this->get('/api/v1/categories/1');
+        $result = $this->withHeaders($this->getHeaders())
+            ->get("/api/v1/categories/{$this->category->id}");
 
         $result->assertStatus(200);
         $json = json_decode($result->getJSON());
         $this->assertObjectHasProperty('data', $json);
-        $this->assertEquals(1, $json->data->id);
+        $this->assertEquals($this->category->id, $json->data->id);
     }
 
     /**
@@ -120,10 +140,11 @@ class CategoriesApiTest extends CIUnitTestCase
             'description' => '수정된 설명'
         ];
 
-        $result = $this->withHeaders([
-            'Authorization' => 'Bearer ' . $this->token
-        ])->withBodyFormat('json')
-            ->put('/api/v1/categories/1', $updateData);
+        $headers = $this->getHeaders();
+
+        $result = $this->withHeaders($headers)
+            ->withBodyFormat('json')
+            ->put("/api/v1/categories/{$this->category->id}", $updateData);
 
         $result->assertStatus(200);
         $json = json_decode($result->getJSON());
@@ -142,9 +163,10 @@ class CategoriesApiTest extends CIUnitTestCase
         // 먼저 카테고리 생성
         $categoryId = $this->createTestCategory();
 
-        $result = $this->withHeaders([
-            'Authorization' => 'Bearer ' . $this->token
-        ])->delete("/api/v1/categories/{$categoryId}");
+        $headers = $this->getHeaders();
+
+        $result = $this->withHeaders($headers)
+            ->delete("/api/v1/categories/{$categoryId}");
 
         $result->assertStatus(204);
     }
@@ -164,7 +186,60 @@ class CategoriesApiTest extends CIUnitTestCase
         $this->assertIsArray($json->data->items);
     }
 
+    /**
+     * @test
+     * GET /api/v1/categories/{id}
+     */
+    public function test_show_category_fails_without_tenant_header(): void
+    {
+        $this->get('/api/v1/categories/1')->assertStatus(400);
+    }
+
+    /**
+     * @test
+     * GET /api/v1/categories/{id}
+     */
+    public function test_show_category_fails_with_invalid_tenant_slug(): void
+    {
+        $this->withHeaders(['X-Tenant-Slug' => 'nonexistent'])
+            ->get('/api/v1/categories/1')
+            ->assertStatus(404);
+    }
+
+    public function test_show_category_isolates_other_tenant(): void
+    {
+        $otherTenantId = $this->createOtherTenant();
+
+        $otherCategory = (new Fabricator(CategoryModel::class))
+            ->setOverrides(['tenant_id' => $otherTenantId])
+            ->create();
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->get("/api/v1/categories/{$otherCategory->id}");
+
+        $result->assertStatus(404);
+
+    }
+
     // Helper Methods
+    private function createOtherTenant(): int
+    {
+        $this->db->table('tenants')
+            ->insert([
+                'subdomain' => 'other-tenant',
+                'name'      => 'other',
+            ]);
+
+        return $this->db->insertID();
+    }
+
+    protected function getHeaders(): array
+    {
+        return [
+            'Authorization' => 'Bearer ' . $this->token,
+            'X-Tenant-Slug' => $this->tenant->subdomain
+        ];
+    }
 
     protected function loginAsAdmin(): void
     {
@@ -185,7 +260,8 @@ class CategoriesApiTest extends CIUnitTestCase
             $this->loginAsAdmin();
         }
 
-        $headers = ['Authorization' => 'Bearer ' . $this->token];
+        $headers = $this->getHeaders();
+
         $payload = [
             'name'        => '테스트 카테고리',
             'slug'        => 'test-category-' . time(),

--- a/tests/api/CommentsApiTest.php
+++ b/tests/api/CommentsApiTest.php
@@ -9,6 +9,7 @@ use App\Enums\CommentState;
 use App\Enums\PostState;
 use App\Models\CommentModel;
 use App\Models\PostModel;
+use App\Models\TenantModel;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
@@ -35,14 +36,18 @@ class CommentsApiTest extends CIUnitTestCase
     protected $migrate = true;
     protected $namespace = null;
     protected $refresh = true;
+    protected $post;
+    protected $tenant;
 
     /**
      * @return string[]
      */
     protected function getHeaders(): array
     {
-        $headers = ['Authorization' => 'Bearer ' . $this->token];
-        return $headers;
+        return [
+            'Authorization' => 'Bearer ' . $this->token,
+            'X-Tenant-Slug' => $this->tenant->subdomain
+        ];
     }
 
     protected function setUp(): void
@@ -51,10 +56,20 @@ class CommentsApiTest extends CIUnitTestCase
 
         $this->resetServices();
 
-        $fabricator = new Fabricator(PostModel::class);
-        $fabricator->setOverrides(['state' => PostState::Published->value]);
-        $post = $fabricator->create();
-        $this->postId = $post->id;
+        $this->tenant = (new Fabricator(TenantModel::class))
+            ->setOverrides(['subdomain' => 'test-tenant-' . uniqid()])
+            ->create();
+
+        $userModel = auth()->getProvider();
+        $admin = $userModel->findByCredentials(['email' => 'admin@example.com']);
+        $userModel->update($admin->id, ['tenant_id' => $this->tenant->id]);
+
+        $this->post = (new Fabricator(PostModel::class))
+            ->setOverrides([
+                'state'     => PostState::PUBLISHED->value,
+                'tenant_id' => $this->tenant->id,
+            ])
+            ->create();
     }
 
     /**
@@ -82,13 +97,13 @@ class CommentsApiTest extends CIUnitTestCase
      */
     public function test_get_comments_filtered_by_post(): void
     {
-        $result = $this->get("/api/v1/comments?post_id={$this->postId}");
+        $result = $this->get("/api/v1/comments?post_id={$this->post->id}");
 
         $result->assertStatus(200);
         $json = json_decode($result->getJSON());
 
         foreach ($json->data->items as $comment) {
-            $this->assertEquals($this->postId, $comment->post_id);
+            $this->assertEquals($this->post->id, $comment->post_id);
         }
     }
 
@@ -99,9 +114,9 @@ class CommentsApiTest extends CIUnitTestCase
      */
     public function test_get_comments_returns_threaded_tree_when_post_id_given(): void
     {
-        $tree = $this->createSimpleTree($this->postId);
+        $tree = $this->createSimpleTree($this->post->id);
 
-        $result = $this->get("/api/v1/comments?post_id={$this->postId}");
+        $result = $this->get("/api/v1/comments?post_id={$this->post->id}");
 
         $result->assertStatus(200);
 
@@ -128,9 +143,9 @@ class CommentsApiTest extends CIUnitTestCase
     {
         config('Comments')->maxDepth = 3;
 
-        $chain = $this->createDeepChain($this->postId, 5);
+        $chain = $this->createDeepChain($this->post->id, 5);
 
-        $result = $this->get("/api/v1/comments?post_id={$this->postId}");
+        $result = $this->get("/api/v1/comments?post_id={$this->post->id}");
 
         $result->assertStatus(200);
 
@@ -159,9 +174,10 @@ class CommentsApiTest extends CIUnitTestCase
      */
     public function test_posts_comments_returns_threaded_tree(): void
     {
-        $tree = $this->createSimpleTree($this->postId);
+        $tree = $this->createSimpleTree($this->post->id);
 
-        $result = $this->get("/api/v1/posts/{$this->postId}/comments");
+        $result = $this->withHeaders($this->getHeaders())
+            ->get("/api/v1/posts/{$this->post->id}/comments");
 
         $result->assertStatus(200);
 
@@ -186,9 +202,9 @@ class CommentsApiTest extends CIUnitTestCase
      */
     public function test_threaded_response_excludes_pending_and_other_post(): void
     {
-        $scenario = $this->createMixedScenario($this->postId);
+        $scenario = $this->createMixedScenario($this->post->id);
 
-        $result = $this->get("/api/v1/comments?post_id={$this->postId}");
+        $result = $this->get("/api/v1/comments?post_id={$this->post->id}");
 
         $result->assertStatus(200);
 
@@ -213,7 +229,7 @@ class CommentsApiTest extends CIUnitTestCase
 
         $headers = $this->getHeaders();
         $commentData = [
-            'post_id' => $this->postId,
+            'post_id' => $this->post->id,
             'content' => '테스트 댓글입니다.'
         ];
 
@@ -235,7 +251,7 @@ class CommentsApiTest extends CIUnitTestCase
     {
         $result = $this->withBodyFormat('json')
             ->post('/api/v1/comments', [
-                'post_id' => $this->postId,
+                'post_id' => $this->post->id,
                 'content' => '댓글'
             ]);
 
@@ -376,14 +392,6 @@ class CommentsApiTest extends CIUnitTestCase
         $this->seeInDatabase('comments', ['id' => $commentId, 'state' => CommentState::PENDING->value]);
     }
 
-    public static function moderationStateProvider(): array
-    {
-        return [
-            'approved' => [CommentState::APPROVED->value],
-            'rejected' => [CommentState::REJECTED->value],
-        ];
-    }
-
     /**
      * @test
      * POST /api/v1/comments/{id}/moderate
@@ -397,15 +405,71 @@ class CommentsApiTest extends CIUnitTestCase
 
         $result = $this->withHeaders($headers)
             ->withBodyFormat('json')
-            ->post(
-                '/api/v1/comments/1/moderate',
-                ['state' => CommentState::APPROVED->value]
+            ->post('/api/v1/comments/1/moderate',
+                [
+                    'state'     => CommentState::APPROVED->value,
+                    'tenant_id' => $this->tenant->id,
+                ]
             );
 
         $result->assertStatus(403);
     }
 
+    /**
+     * @test
+     * GET /api/v1/comments/{id}
+     */
+    public function test_posts_comments_fails_without_tenant_header(): void
+    {
+        $this->get("/api/v1/posts/{$this->post->id}/comments")
+            ->assertStatus(400);
+    }
+
+    /**
+     * @test
+     * GET /api/v1/comments/{id}
+     */
+    public function test_posts_comments_fails_with_invalid_tenant_slug(): void
+    {
+        $this->withHeaders(['X-Tenant-Slug' => 'invalid-slug'])
+            ->get("/api/v1/posts/{$this->post->id}/comments")
+            ->assertStatus(404);
+    }
+
+    public function test_posts_comments_isolates_other_tenant(): void
+    {
+        $otherTenantId = $this->createTenant();
+        $otherPost = (new Fabricator(PostModel::class))
+            ->setOverrides([
+                'tenant_id' => $otherTenantId,
+                'state'     => PostState::PUBLISHED->value,
+            ])->create();
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->get("/api/v1/posts/{$otherPost->id}/comments");
+
+        $result->assertStatus(404);
+    }
+
     // Helper Methods
+    private function createTenant(): int
+    {
+        $this->db->table('tenants')
+            ->insert([
+                'subdomain' => 'other-tenant',
+                'name'      => 'other',
+            ]);
+
+        return $this->db->insertID();
+    }
+
+    public static function moderationStateProvider(): array
+    {
+        return [
+            'approved' => [CommentState::APPROVED->value],
+            'rejected' => [CommentState::REJECTED->value],
+        ];
+    }
 
     protected function loginAsUser(): void
     {
@@ -456,7 +520,7 @@ class CommentsApiTest extends CIUnitTestCase
         $result = $this->withHeaders($this->getHeaders())
             ->withBodyFormat('json')
             ->post('/api/v1/comments', [
-                'post_id' => $this->postId,
+                'post_id' => $this->post->id,
                 'content' => '테스트 댓글'
             ]);
 
@@ -477,15 +541,30 @@ class CommentsApiTest extends CIUnitTestCase
     {
         $fab = new Fabricator(CommentModel::class);
 
-        $fab->setOverrides(['post_id' => $postId, 'parent_id' => null, 'state' => CommentState::APPROVED->value]);
+        $fab->setOverrides([
+            'post_id'   => $postId,
+            'parent_id' => null,
+            'state'     => CommentState::APPROVED->value
+        ]);
+
         /** @var CommentEntity $root */
         $root = $fab->create();
 
-        $fab->setOverrides(['post_id' => $postId, 'parent_id' => $root->id, 'state' => CommentState::APPROVED->value]);
+        $fab->setOverrides([
+            'post_id'   => $postId,
+            'parent_id' => $root->id,
+            'state'     => CommentState::APPROVED->value
+        ]);
+
         /** @var CommentEntity $child */
         $child = $fab->create();
 
-        $fab->setOverrides(['post_id' => $postId, 'parent_id' => $child->id, 'state' => CommentState::APPROVED->value]);
+        $fab->setOverrides([
+            'post_id'   => $postId,
+            'parent_id' => $child->id,
+            'state'     => CommentState::APPROVED->value
+        ]);
+
         /** @var CommentEntity $grandchild */
         $grandchild = $fab->create();
 

--- a/tests/api/CommentsApiTest.php
+++ b/tests/api/CommentsApiTest.php
@@ -407,8 +407,7 @@ class CommentsApiTest extends CIUnitTestCase
             ->withBodyFormat('json')
             ->post('/api/v1/comments/1/moderate',
                 [
-                    'state'     => CommentState::APPROVED->value,
-                    'tenant_id' => $this->tenant->id,
+                    'state' => CommentState::APPROVED->value,
                 ]
             );
 
@@ -454,13 +453,11 @@ class CommentsApiTest extends CIUnitTestCase
     // Helper Methods
     private function createTenant(): int
     {
-        $this->db->table('tenants')
-            ->insert([
-                'subdomain' => 'other-tenant',
-                'name'      => 'other',
-            ]);
+        $tenant = (new Fabricator(TenantModel::class))
+            ->setOverrides(['subdomain' => 'other-tenant-' . uniqid()])
+            ->create();
 
-        return $this->db->insertID();
+        return $tenant->id;
     }
 
     public static function moderationStateProvider(): array

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -8,6 +8,7 @@ use App\Enums\UserRole;
 use App\Models\CategoryModel;
 use App\Models\PostModel;
 use App\Models\TagModel;
+use App\Models\TenantModel;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
@@ -33,6 +34,7 @@ class PostsApiTest extends CIUnitTestCase
     protected $migrate = true;
     protected $namespace = null;
     protected $refresh = true;
+    protected $tenant;
 
     protected function setUp(): void
     {
@@ -40,14 +42,24 @@ class PostsApiTest extends CIUnitTestCase
 
         $this->resetServices();
 
+        $this->tenant = (new Fabricator(TenantModel::class))
+            ->setOverrides(['subdomain' => 'test-tenant-' . uniqid()])
+            ->create();
+
+        // 시드 admin user의 tenant_id를 새 tenant로 동기화
+        $userModel = auth()->getProvider();
+        $admin = $userModel->findByCredentials(['email' => 'admin@example.com']);
+        $userModel->update($admin->id, ['tenant_id' => $this->tenant->id]);
+
         // 테스트용 포스트 데이터
         $this->testPost = [
+            'tenant_id'   => $this->tenant->id,
+            'category_id' => 1,
             'title'       => '테스트 포스트',
             'slug'        => 'test-post',
             'content'     => '테스트 포스트 내용입니다.',
             'excerpt'     => '포스트 요약',
-            'status'      => 'draft',
-            'category_id' => 1,
+            'state'       => 'draft',
         ];
     }
 
@@ -59,7 +71,7 @@ class PostsApiTest extends CIUnitTestCase
     public function test_get_posts_list_without_auth(): void
     {
         $fabricator = new Fabricator(PostModel::class);
-        $fabricator->setOverrides(['state' => PostState::Published]);
+        $fabricator->setOverrides(['state' => PostState::PUBLISHED]);
         $fabricator->create(10);
 
         $result = $this->get('/api/v1/posts');
@@ -102,13 +114,13 @@ class PostsApiTest extends CIUnitTestCase
 
         $fabricator->setOverrides([
             'title' => '테스트 포스트',
-            'state' => PostState::Published
+            'state' => PostState::PUBLISHED
         ]);
         $fabricator->create();
 
         $fabricator->setOverrides([
             'title' => '검색에 포함되면 안되는 포스트',
-            'state' => PostState::Published
+            'state' => PostState::PUBLISHED
         ]);
         $fabricator->create();
 
@@ -132,7 +144,7 @@ class PostsApiTest extends CIUnitTestCase
     public function test_get_posts_with_search_keyword_filtering_no_results(): void
     {
         $fabricator = new Fabricator(PostModel::class);
-        $fabricator->setOverrides(['state' => PostState::Published]);
+        $fabricator->setOverrides(['state' => PostState::PUBLISHED]);
         $fabricator->create(2);
 
         $result = $this->get('/api/v1/posts?search=nonexistent');
@@ -154,7 +166,7 @@ class PostsApiTest extends CIUnitTestCase
     public function test_get_posts_list_excludes_draft_posts(): void
     {
         $fabricator = new Fabricator(PostModel::class);
-        $fabricator->setOverrides(['state' => PostState::Draft]);
+        $fabricator->setOverrides(['state' => PostState::DRAFT]);
         $fabricator->create(10);
 
         $result = $this->get('/api/v1/posts');
@@ -176,7 +188,7 @@ class PostsApiTest extends CIUnitTestCase
     public function test_get_posts_list_includes_published_posts(): void
     {
         $fabricator = new Fabricator(PostModel::class);
-        $fabricator->setOverrides(['state' => PostState::Published]);
+        $fabricator->setOverrides(['state' => PostState::PUBLISHED]);
         $fabricator->create(10);
 
         $result = $this->get('/api/v1/posts');
@@ -200,17 +212,17 @@ class PostsApiTest extends CIUnitTestCase
         $fabricator = new Fabricator(PostModel::class);
 
         $fabricator->setOverrides([
-            'state' => PostState::Published,
+            'state' => PostState::PUBLISHED,
             'title' => '테스트 검색 게시글'
         ])->create();
 
         $fabricator->setOverrides([
-            'state' => PostState::Published,
+            'state' => PostState::PUBLISHED,
             'title' => '테스트 게시글'
         ])->create();
 
         $fabricator->setOverrides([
-            'state' => PostState::Draft,
+            'state' => PostState::DRAFT,
             'title' => '조회되면 안되는 검색 게시글'
         ])->create();
 
@@ -241,12 +253,12 @@ class PostsApiTest extends CIUnitTestCase
         $postFabricator = new Fabricator(PostModel::class);
 
         $postFabricator->setOverrides([
-            'state'       => PostState::Published,
+            'state'       => PostState::PUBLISHED,
             'category_id' => $cat1->id,
         ])->create(1);
 
         $postFabricator->setOverrides([
-            'state'       => PostState::Published,
+            'state'       => PostState::PUBLISHED,
             'category_id' => $cat2->id,
         ])->create(4);
 
@@ -309,13 +321,13 @@ class PostsApiTest extends CIUnitTestCase
         $postFabricator = new Fabricator(PostModel::class);
 
         $postFabricator->setOverrides([
-            'state'       => PostState::Published,
+            'state'       => PostState::PUBLISHED,
             'category_id' => $cat1->id,
             'title'       => 'test'
         ])->create(1);
 
         $postFabricator->setOverrides([
-            'state'       => PostState::Published,
+            'state'       => PostState::PUBLISHED,
             'category_id' => $cat2->id,
             'title'       => 'test'
         ])->create(1);
@@ -391,14 +403,26 @@ class PostsApiTest extends CIUnitTestCase
         $tags = $this->createFakeTags(2);
 
         $fabricator = new Fabricator(PostModel::class);
-        $post = $fabricator->setOverrides(['state' => PostState::Published])->create();
+        $post = $fabricator->setOverrides([
+            'state'    => PostState::PUBLISHED->value,
+            'tenant_id' => $this->tenant->id,
+        ])->create();
 
         $this->db->table('post_tags')->insertBatch([
-            ['post_id' => $post->id, 'tag_id' => $tags[0]->id, 'tenant_id' => 1],
-            ['post_id' => $post->id, 'tag_id' => $tags[1]->id, 'tenant_id' => 1],
+            [
+                'post_id'   => $post->id,
+                'tag_id'    => $tags[0]->id,
+                'tenant_id' => $this->tenant->id
+            ],
+            [
+                'post_id'   => $post->id,
+                'tag_id'    => $tags[1]->id,
+                'tenant_id' => $this->tenant->id
+            ],
         ]);
 
-        $result = $this->get("/api/v1/posts/{$post->id}");
+        $result = $this->withHeaders($this->getHeaders())
+            ->get("/api/v1/posts/{$post->id}");
 
         $result->assertStatus(200);
 
@@ -416,7 +440,7 @@ class PostsApiTest extends CIUnitTestCase
     {
         $provider = auth()->getProvider();
         $provider->save(new User([
-            'tenant_id' => 1,
+            'tenant_id' => $this->tenant->id,
             'email'     => 'owner@example.com',
             'username'  => 'owner',
             'password'  => 'password123',
@@ -575,9 +599,10 @@ class PostsApiTest extends CIUnitTestCase
      */
     public function test_get_post_by_id(): void
     {
-        $postId = $this->createTestPost();
+        $postId = $this->createTestPost(PostState::PUBLISHED->value);
 
-        $result = $this->get("/api/v1/posts/{$postId}");
+        $result = $this->withHeaders($this->getHeaders())
+            ->get("/api/v1/posts/{$postId}");
 
         $result->assertStatus(200);
         $result->assertJSONFragment([
@@ -596,7 +621,8 @@ class PostsApiTest extends CIUnitTestCase
      */
     public function test_get_nonexistent_post_returns_404(): void
     {
-        $result = $this->get('/api/v1/posts/99999');
+        $result = $this->withHeaders($this->getHeaders())
+            ->get('/api/v1/posts/99999');
 
         $result->assertStatus(404);
         $result->assertJSONFragment([
@@ -666,9 +692,8 @@ class PostsApiTest extends CIUnitTestCase
         $this->loginAsAdmin();
         $postId = $this->createTestPost();
 
-        $result = $this->withHeaders([
-            'Authorization' => 'Bearer ' . $this->token
-        ])->delete("/api/v1/posts/{$postId}");
+        $result = $this->withHeaders($this->getHeaders())
+            ->delete("/api/v1/posts/{$postId}");
 
         $result->assertStatus(204);
 
@@ -711,8 +736,9 @@ class PostsApiTest extends CIUnitTestCase
         $result->assertStatus(200);
 
         // 포스트 상태가 published로 변경되었는지 확인
-        $getResult = $this->get("/api/v1/posts/{$postId}");
+        $getResult = $this->withHeaders($headers)->get("/api/v1/posts/{$postId}");
         $publishedPost = json_decode($getResult->getJSON());
+
         $this->assertEquals('published', $publishedPost->data->state);
     }
 
@@ -745,18 +771,20 @@ class PostsApiTest extends CIUnitTestCase
         $headers = $this->getHeaders();
 
         // 정상 케이스를 테스트하기 위해 먼저 publish
-        $result = $this->withHeaders($headers)->post("/api/v1/posts/{$postId}/publish");
+        $result = $this->withHeaders($headers)
+            ->post("/api/v1/posts/{$postId}/publish");
 
         $result->assertStatus(200);
 
-        $result = $this->withHeaders($headers)->post("/api/v1/posts/{$postId}/unpublish");
+        $result = $this->withHeaders($headers)
+            ->post("/api/v1/posts/{$postId}/unpublish");
 
         $result->assertStatus(200);
 
-        $response = $this->get("/api/v1/posts/{$postId}");
-        $unpublishedPost = json_decode($response->getJSON());
-
-        $this->assertEquals('draft', $unpublishedPost->data->state);
+        $this->seeInDatabase('posts', [
+            'id'    => $postId,
+            'state' => PostState::DRAFT->value,
+        ]);
     }
 
     /**
@@ -953,10 +981,10 @@ class PostsApiTest extends CIUnitTestCase
         $result = $this->withHeaders($headers)
             ->withBodyFormat('json')
             ->post('/api/v1/posts', [
-                'title' => '테스트 포스트',
-                'content' => '테스트 포스트 내용입니다.',
+                'title'       => '테스트 포스트',
+                'content'     => '테스트 포스트 내용입니다.',
                 'category_id' => 1,
-                'tags' => '',
+                'tags'        => '',
             ]);
 
         $result->assertStatus(422);
@@ -965,6 +993,55 @@ class PostsApiTest extends CIUnitTestCase
         $errors = $json['messages'] ?? $json['errors'] ?? [];
         $this->assertArrayHasKey('tags', $errors);
     }
+
+    public function test_show_post_fails_without_tenant_header(): void
+    {
+        $this->get('/api/v1/posts/1')->assertStatus(400);
+    }
+
+    public function test_show_post_fails_with_invalid_tenant_slug(): void
+    {
+        $this->withHeaders(['X-Tenant-Slug' => 'nonexistent'])
+        ->get('/api/v1/posts/1')->assertStatus(404);
+    }
+
+    /**
+     * @test
+     * GET /api/v1/posts/{id}
+     * 본인 tenant로 인증/요청 중인 사용자가, 다른 tenant의 post id를 알고 있어도 접근 못 함
+     */
+    public function test_show_post_isolates_other_tenant(): void
+    {
+        // 1. 다른 테넌트와 그 소속 published post 생성
+        $otherTenantId = $this->createOtherTenant();
+        $otherPost = (new Fabricator(PostModel::class))
+            ->setOverrides([
+                'tenant_id' => $otherTenantId,
+                'state'     => PostState::PUBLISHED->value,
+            ])->create();
+
+        // 2. 본인 tenant 헤더로 다른 tenant의 post 조회 시도
+        $result = $this->withHeaders($this->getHeaders())
+            ->get("/api/v1/posts/{$otherPost->id}");
+
+        // 3. 격리 작동 검증
+        $result->assertStatus(404);
+    }
+
+    public function test_show_post_excludes_draft_state(): void
+    {
+        $draftPost = (new Fabricator(PostModel::class))
+            ->setOverrides([
+                'tenant_id' => $this->tenant->id,
+                'state' => PostState::DRAFT->value,
+            ])->create();
+
+        $result = $this->withHeaders($this->getHeaders())
+            ->get("/api/v1/posts/{$draftPost->id}");
+
+        $result->assertStatus(404);
+    }
+
     /**
      * GET /api/v1/posts/{id}/comments
      *
@@ -996,11 +1073,12 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * 테스트용 포스트 생성 및 ID 반환
      */
-    protected function createTestPost(): int
+    protected function createTestPost($state = 'draft'): int
     {
         if (!$this->token) {
             $this->loginAsAdmin();
         }
+
         $headers = $this->getHeaders();
 
         $result = $this->withHeaders($headers)
@@ -1008,10 +1086,13 @@ class PostsApiTest extends CIUnitTestCase
             ->post('/api/v1/posts', $this->testPost);
 
         $json = json_decode($result->getJSON());
+        $postId = (int)$json->data->id;
 
-        $this->assertNotNull($json->data->id ?? null, 'createTestPost failed: ' . $result->getJSON());
+        if ($state !== 'draft') {
+            model(PostModel::class)->update($postId, ['state' => $state]);
+        }
 
-        return (int)$json->data->id;
+        return $postId;
     }
 
     protected function getHeaders(User $user = null): array
@@ -1019,7 +1100,8 @@ class PostsApiTest extends CIUnitTestCase
         $token = $user ? $user->generateAccessToken('test')->raw_token : $this->token;
 
         return [
-            'Authorization' => 'Bearer ' . $token
+            'Authorization' => 'Bearer ' . $token,
+            'X-Tenant-Slug' => $this->tenant->subdomain
         ];
     }
 
@@ -1029,7 +1111,7 @@ class PostsApiTest extends CIUnitTestCase
 
         // 게시글 작성자
         $provider->save(new User([
-            'tenant_id' => 1,
+            'tenant_id' => $this->tenant->id,
             'email'     => 'owner@example.com',
             'username'  => 'owner',
             'password'  => 'password123',
@@ -1039,7 +1121,7 @@ class PostsApiTest extends CIUnitTestCase
 
         // 로그인한 사용자
         $provider->save(new User([
-            'tenant_id' => 1,
+            'tenant_id' => $this->tenant->id,
             'email'     => 'tester@example.com',
             'username'  => 'tester',
             'password'  => 'password123',
@@ -1064,13 +1146,19 @@ class PostsApiTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(TagModel::class);
 
-        return $fabricator->setOverrides(['tenant_id' => 1])->create($count);
+        return $fabricator
+            ->setOverrides(['tenant_id' => $this->tenant->id])
+            ->create($count);
     }
 
     protected function attachTags($postId, $tags)
     {
         $this->db->table('post_tags')->insertBatch(
-            array_map(fn($tagId) => ['post_id' => $postId, 'tag_id' => $tagId, 'tenant_id' => 1], $tags)
+            array_map(fn($tagId) => [
+                'post_id'   => $postId,
+                'tag_id'    => $tagId,
+                'tenant_id' => $this->tenant->id
+            ], $tags)
         );
     }
 

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -46,6 +46,9 @@ class PostsApiTest extends CIUnitTestCase
             ->setOverrides(['subdomain' => 'test-tenant-' . uniqid()])
             ->create();
 
+        // PostModel::fake() 등 fabricate가 service('tenant')를 참조하도록 미리 세팅
+        service('tenant')->setTenant($this->tenant);
+
         // 시드 admin user의 tenant_id를 새 tenant로 동기화
         $userModel = auth()->getProvider();
         $admin = $userModel->findByCredentials(['email' => 'admin@example.com']);
@@ -59,7 +62,7 @@ class PostsApiTest extends CIUnitTestCase
             'slug'        => 'test-post',
             'content'     => '테스트 포스트 내용입니다.',
             'excerpt'     => '포스트 요약',
-            'state'       => 'draft',
+            'state'       => PostState::DRAFT->value,
         ];
     }
 
@@ -74,7 +77,7 @@ class PostsApiTest extends CIUnitTestCase
         $fabricator->setOverrides(['state' => PostState::PUBLISHED]);
         $fabricator->create(10);
 
-        $result = $this->get('/api/v1/posts');
+        $result = $this->withHeaders($this->getHeaders())->get('/api/v1/posts');
 
         $result->assertStatus(200);
 
@@ -92,7 +95,7 @@ class PostsApiTest extends CIUnitTestCase
      */
     public function test_get_posts_with_pagination(): void
     {
-        $result = $this->get('/api/v1/posts?page=1&per_page=10');
+        $result = $this->withHeaders($this->getHeaders())->get('/api/v1/posts?page=1&per_page=10');
 
         $result->assertStatus(200);
 
@@ -124,7 +127,7 @@ class PostsApiTest extends CIUnitTestCase
         ]);
         $fabricator->create();
 
-        $result = $this->get('/api/v1/posts?search=테스트');
+        $result = $this->withHeaders($this->getHeaders())->get('/api/v1/posts?search=테스트');
 
         $result->assertStatus(200);
 
@@ -147,7 +150,7 @@ class PostsApiTest extends CIUnitTestCase
         $fabricator->setOverrides(['state' => PostState::PUBLISHED]);
         $fabricator->create(2);
 
-        $result = $this->get('/api/v1/posts?search=nonexistent');
+        $result = $this->withHeaders($this->getHeaders())->get('/api/v1/posts?search=nonexistent');
 
         $result->assertStatus(200);
 
@@ -169,7 +172,7 @@ class PostsApiTest extends CIUnitTestCase
         $fabricator->setOverrides(['state' => PostState::DRAFT]);
         $fabricator->create(10);
 
-        $result = $this->get('/api/v1/posts');
+        $result = $this->withHeaders($this->getHeaders())->get('/api/v1/posts');
 
         $result->assertStatus(200);
 
@@ -191,7 +194,7 @@ class PostsApiTest extends CIUnitTestCase
         $fabricator->setOverrides(['state' => PostState::PUBLISHED]);
         $fabricator->create(10);
 
-        $result = $this->get('/api/v1/posts');
+        $result = $this->withHeaders($this->getHeaders())->get('/api/v1/posts');
 
         $result->assertStatus(200);
 
@@ -226,7 +229,7 @@ class PostsApiTest extends CIUnitTestCase
             'title' => '조회되면 안되는 검색 게시글'
         ])->create();
 
-        $result = $this->get('/api/v1/posts?search=검색');
+        $result = $this->withHeaders($this->getHeaders())->get('/api/v1/posts?search=검색');
         $result->assertStatus(200);
 
         $json = json_decode($result->getJSON());
@@ -262,7 +265,7 @@ class PostsApiTest extends CIUnitTestCase
             'category_id' => $cat2->id,
         ])->create(4);
 
-        $result = $this->get("/api/v1/posts?category_id={$cat1->id}");
+        $result = $this->withHeaders($this->getHeaders())->get("/api/v1/posts?category_id={$cat1->id}");
 
         $result->assertStatus(200);
 
@@ -281,7 +284,7 @@ class PostsApiTest extends CIUnitTestCase
      */
     public function test_get_posts_by_not_exist_category_id(): void
     {
-        $result = $this->get('/api/v1/posts?category_id=9999');
+        $result = $this->withHeaders($this->getHeaders())->get('/api/v1/posts?category_id=9999');
 
         $result->assertStatus(200);
 
@@ -299,7 +302,7 @@ class PostsApiTest extends CIUnitTestCase
      */
     public function test_get_posts_by_invalid_category_id(): void
     {
-        $result = $this->get('/api/v1/posts?category_id=invalid');
+        $result = $this->withHeaders($this->getHeaders())->get('/api/v1/posts?category_id=invalid');
 
         $result->assertStatus(422);
     }
@@ -333,7 +336,7 @@ class PostsApiTest extends CIUnitTestCase
         ])->create(1);
 
 
-        $result = $this->get("/api/v1/posts?category_id={$cat1->id}&search=test");
+        $result = $this->withHeaders($this->getHeaders())->get("/api/v1/posts?category_id={$cat1->id}&search=test");
 
         $result->assertStatus(200);
         $json = json_decode($result->getJSON());
@@ -996,13 +999,26 @@ class PostsApiTest extends CIUnitTestCase
 
     public function test_show_post_fails_without_tenant_header(): void
     {
-        $this->get('/api/v1/posts/1')->assertStatus(400);
+        $post = (new Fabricator(PostModel::class))
+            ->setOverrides([
+                'tenant_id' => $this->tenant->id,
+                'state'     => PostState::PUBLISHED->value,
+            ])->create();
+
+        $this->get("/api/v1/posts/{$post->id}")->assertStatus(400);
     }
 
     public function test_show_post_fails_with_invalid_tenant_slug(): void
     {
+        $post = (new Fabricator(PostModel::class))
+            ->setOverrides([
+                'tenant_id' => $this->tenant->id,
+                'state'     => PostState::PUBLISHED->value,
+            ])->create();
+
         $this->withHeaders(['X-Tenant-Slug' => 'nonexistent'])
-        ->get('/api/v1/posts/1')->assertStatus(404);
+            ->get("/api/v1/posts/{$post->id}")
+            ->assertStatus(404);
     }
 
     /**
@@ -1073,7 +1089,7 @@ class PostsApiTest extends CIUnitTestCase
     /**
      * 테스트용 포스트 생성 및 ID 반환
      */
-    protected function createTestPost($state = 'draft'): int
+    protected function createTestPost(string $state = PostState::DRAFT->value): int
     {
         if (!$this->token) {
             $this->loginAsAdmin();
@@ -1088,7 +1104,7 @@ class PostsApiTest extends CIUnitTestCase
         $json = json_decode($result->getJSON());
         $postId = (int)$json->data->id;
 
-        if ($state !== 'draft') {
+        if ($state !== PostState::DRAFT->value) {
             model(PostModel::class)->update($postId, ['state' => $state]);
         }
 
@@ -1164,13 +1180,11 @@ class PostsApiTest extends CIUnitTestCase
 
     private function createOtherTenant(): int
     {
-        $this->db->table('tenants')
-            ->insert([
-                'subdomain' => 'other-tenant',
-                'name'      => 'other',
-            ]);
+        $tenant = (new Fabricator(TenantModel::class))
+            ->setOverrides(['subdomain' => 'other-tenant-' . uniqid()])
+            ->create();
 
-        return $this->db->insertID();
+        return $tenant->id;
     }
 
     private function createTagInTenant(int $tenantId, int $count): array

--- a/tests/unit/EntityEnumCastingTest.php
+++ b/tests/unit/EntityEnumCastingTest.php
@@ -27,16 +27,16 @@ class EntityEnumCastingTest extends CIUnitTestCase
     {
         $post = new PostEntity(['state' => 'published']);
         $this->assertInstanceOf(PostState::class, $post->state);
-        $this->assertSame(PostState::Published, $post->state);
+        $this->assertSame(PostState::PUBLISHED, $post->state);
     }
 
     #[Test]
     public function post_entity_accepts_enum_assignment(): void
     {
         $post = new PostEntity();
-        $post->state = PostState::Draft;
-        $this->assertSame(PostState::Draft, $post->state);
-        $this->assertSame(PostState::Draft->value, $post->toRawArray()['state']);
+        $post->state = PostState::DRAFT;
+        $this->assertSame(PostState::DRAFT, $post->state);
+        $this->assertSame(PostState::DRAFT->value, $post->toRawArray()['state']);
     }
 
     #[Test]

--- a/tests/unit/EnumTest.php
+++ b/tests/unit/EnumTest.php
@@ -24,24 +24,24 @@ class EnumTest extends CIUnitTestCase
     #[Test]
     public function post_state_has_correct_backing_values(): void
     {
-        $this->assertSame('draft',     PostState::Draft->value);
-        $this->assertSame('published', PostState::Published->value);
-        $this->assertSame('archived',  PostState::Archived->value);
+        $this->assertSame('draft', PostState::DRAFT->value);
+        $this->assertSame('published', PostState::PUBLISHED->value);
+        $this->assertSame('archived', PostState::ARCHIVED->value);
     }
 
     #[Test]
     public function post_state_is_public_only_when_published(): void
     {
-        $this->assertTrue(PostState::Published->isPublic());
-        $this->assertFalse(PostState::Draft->isPublic());
-        $this->assertFalse(PostState::Archived->isPublic());
+        $this->assertTrue(PostState::PUBLISHED->isPublic());
+        $this->assertFalse(PostState::DRAFT->isPublic());
+        $this->assertFalse(PostState::ARCHIVED->isPublic());
     }
 
     #[Test]
     public function post_state_can_be_created_from_string(): void
     {
-        $this->assertSame(PostState::Published, PostState::from('published'));
-        $this->assertSame(PostState::Draft,     PostState::from('draft'));
+        $this->assertSame(PostState::PUBLISHED, PostState::from('published'));
+        $this->assertSame(PostState::DRAFT, PostState::from('draft'));
     }
 
     // -------------------------------------------------------------------------
@@ -52,8 +52,8 @@ class EnumTest extends CIUnitTestCase
     public function user_role_has_correct_backing_values(): void
     {
         $this->assertSame('superadmin', UserRole::Superadmin->value);
-        $this->assertSame('admin',      UserRole::Admin->value);
-        $this->assertSame('user',       UserRole::User->value);
+        $this->assertSame('admin', UserRole::Admin->value);
+        $this->assertSame('user', UserRole::User->value);
     }
 
     #[Test]
@@ -71,8 +71,8 @@ class EnumTest extends CIUnitTestCase
     #[Test]
     public function media_type_has_correct_backing_values(): void
     {
-        $this->assertSame('image',    MediaType::Image->value);
-        $this->assertSame('video',    MediaType::Video->value);
+        $this->assertSame('image', MediaType::Image->value);
+        $this->assertSame('video', MediaType::Video->value);
         $this->assertSame('document', MediaType::Document->value);
     }
 
@@ -90,25 +90,25 @@ class EnumTest extends CIUnitTestCase
     #[Test]
     public function each_enum_label_returns_expected_string(): void
     {
-        $this->assertSame('임시저장', PostState::Draft->label());
-        $this->assertSame('게시됨',   PostState::Published->label());
-        $this->assertSame('보관됨',   PostState::Archived->label());
+        $this->assertSame('임시저장', PostState::DRAFT->label());
+        $this->assertSame('게시됨', PostState::PUBLISHED->label());
+        $this->assertSame('보관됨', PostState::ARCHIVED->label());
 
-        $this->assertSame('Admin',     UserRole::Admin->label());
+        $this->assertSame('Admin', UserRole::Admin->label());
         $this->assertSame('Super Admin', UserRole::Superadmin->label());
 
-        $this->assertSame('이미지',  MediaType::Image->label());
+        $this->assertSame('이미지', MediaType::Image->label());
         $this->assertSame('동영상', MediaType::Video->label());
-        $this->assertSame('문서',   MediaType::Document->label());
+        $this->assertSame('문서', MediaType::Document->label());
     }
 
     #[Test]
     public function enum_labels_are_unique_across_all_enums(): void
     {
         $labels = [
-            PostState::Draft->label(),
-            PostState::Published->label(),
-            PostState::Archived->label(),
+            PostState::DRAFT->label(),
+            PostState::PUBLISHED->label(),
+            PostState::ARCHIVED->label(),
             MediaType::Image->label(),
             MediaType::Video->label(),
             MediaType::Document->label(),

--- a/tests/unit/TransformerTest.php
+++ b/tests/unit/TransformerTest.php
@@ -38,7 +38,7 @@ class TransformerTest extends CIUnitTestCase
             'slug'         => 'test-post',
             'excerpt'      => '요약',
             'content'      => '본문',
-            'state'        => PostState::Published,
+            'state'        => PostState::PUBLISHED,
             'category_id'  => 2,
             'writer_id'    => 3,
             'published_at' => '2025-01-01T00:00:00Z',
@@ -62,7 +62,7 @@ class TransformerTest extends CIUnitTestCase
     {
         $resource = [
             'id'         => 1, 'title' => 'T', 'slug' => 's', 'content' => 'c',
-            'state'      => PostState::Draft,
+            'state'      => PostState::DRAFT,
             'writer_id'  => 1,
             'created_at' => null, 'updated_at' => null,
         ];
@@ -182,7 +182,7 @@ class TransformerTest extends CIUnitTestCase
             'user_id'    => 5,
             'parent_id'  => null,
             'content'    => '댓글 내용',
-            'state'     => 'approved',
+            'state'      => 'approved',
             'created_at' => '2025-01-01T00:00:00Z',
             'updated_at' => '2025-01-01T00:00:00Z',
         ];


### PR DESCRIPTION
## Summary
- `PostsController::show()`/`comments()`, `CategoriesController::show()`는 공개 엔드포인트라 `auth()->user()->tenant_id`로 격리할 수 없어 ID만 알면 다른 테넌트 데이터 접근 가능.
- `X-Tenant-Slug` 헤더 + 신규 `ApiTenantFilter`로 테넌트 식별 → 컨트롤러에서 `where('tenant_id', service('tenant')->getId())` 스코프 적용.
- 격리 회귀 테스트 10건 추가 (Posts 4 / Categories 3 / Comments 3).

## 결정
- **헤더 방식 (`X-Tenant-Slug`)**: #97(서브도메인 기반 식별) 완료 전 단기 대응. 향후 폐기 예정.
- **누락(400) vs 미존재(404) 분리**: 호출자 디버깅 친화. subdomain은 외부 공개 정보라 정보 노출 우려 작음.
- **`PostsController::show()`에 state=published 필터 추가**: 공개 엔드포인트는 published만 노출 (`index()`와 정책 일관).
- **부수 — PostState enum UPPER_CASE 통일**: 작업 과정에서 case 컨벤션 정리. 한 PR에 묶음 (스코프 작음).

## 부채 (별도 이슈 분리 예정)
- `PostsController::create` 검증 `is_not_unique[categories.id]`에 tenant scope 없음 — 다른 tenant의 category id를 payload로 보내도 통과.
- `TenantModel::fake()`의 subdomain이 가끔 `min_length[3]` 미달 — 현재 setOverrides로 우회. fake 정의 자체 정리 필요.
- `ApiTenantFilter`는 #97 머지 후 폐기 예정.

## 남은 작업
- 없음. #97 진행 시 본 필터 제거 + 컨트롤러 스코프 로직 자동화 검토.

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 멀티테넌트 API 필터 적용으로 요청별 테넌트 검증 및 자동 설정 추가
  * API 요청에 테넌트 식별 헤더(X-Tenant-Slug) 필수화

* **버그 수정**
  * 엔드포인트 전반의 테넌트 격리 강화로 교차 테넌트 접근 차단 및 데이터 보안 개선
  * 게시물 공개 상태 판정 로직 안정화

* **리팩토링**
  * 열거형 멤버명 명명 규칙을 대문자 스타일로 통일

* **테스트**
  * 테넌트 인식 및 헤더 검증을 포함한 API/단위 테스트 대폭 확장

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/134)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->