### PR TITLE
🔒 fix: category_id 검증에 테넌트 스코프 적용 (#135)

### DIFF
--- a/app/Config/Validation.php
+++ b/app/Config/Validation.php
@@ -4,6 +4,7 @@ namespace Config;
 
 use App\Validation\EnumRules;
 use App\Validation\TagRules;
+use App\Validation\TenantRules;
 use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Validation\StrictRules\CreditCardRules;
 use CodeIgniter\Validation\StrictRules\FileRules;
@@ -29,6 +30,7 @@ class Validation extends BaseConfig
         CreditCardRules::class,
         TagRules::class,
         EnumRules::class,
+        TenantRules::class,
     ];
 
     /**

--- a/app/Controllers/Api/V1/PostsController.php
+++ b/app/Controllers/Api/V1/PostsController.php
@@ -114,7 +114,7 @@ class PostsController extends BaseApiController
         $rules = [
             'title'       => 'required|min_length[3]|max_length[255]',
             'content'     => 'required|min_length[10]',
-            'category_id' => 'required|integer|is_not_unique[categories.id]',
+            'category_id' => 'required|integer|is_not_unique_in_tenant[categories.id]',
             'tags'        => 'if_exist|is_array|is_array_of_int',
         ];
 
@@ -162,7 +162,7 @@ class PostsController extends BaseApiController
         $rules = [
             'title'       => 'if_exist|min_length[3]|max_length[255]',
             'content'     => 'if_exist|min_length[10]',
-            'category_id' => 'if_exist|integer|is_not_unique[categories.id]',
+            'category_id' => 'if_exist|integer|is_not_unique_in_tenant[categories.id]',
             'tags'        => 'if_exist|is_array|is_array_of_int',
         ];
 

--- a/app/Language/en/Validation.php
+++ b/app/Language/en/Validation.php
@@ -1,4 +1,5 @@
 <?php
 
-// override core en language system validation or define your own en language validation message
-return [];
+return [
+    'is_not_unique_in_tenant' => 'The {field} field must reference an existing record in your tenant'
+];

--- a/app/Validation/TenantRules.php
+++ b/app/Validation/TenantRules.php
@@ -6,7 +6,16 @@ class TenantRules
 {
     public function is_not_unique_in_tenant($value, ?string $params, array $data, ?string &$error = null): bool
     {
-        $param = explode('.', $params);
+        if ($params === null || !str_contains($params, '.')) {
+            return false;
+        }
+
+        $param = explode('.', $params, 2);
+
+        if (count($param) < 2 || $param[0] === '' || $param[1] === '') {
+            return false;
+        }
+
         $table = $param[0];
         $column = $param[1];
         $tenantId = auth()->user()?->tenant_id;

--- a/app/Validation/TenantRules.php
+++ b/app/Validation/TenantRules.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Validation;
+
+class TenantRules
+{
+    public function is_not_unique_in_tenant($value, ?string $params, array $data, ?string &$error = null): bool
+    {
+        $param = explode('.', $params);
+        $table = $param[0];
+        $column = $param[1];
+        $tenantId = auth()->user()?->tenant_id;
+
+        if (!$tenantId) {
+            return false;
+        }
+
+        $count = db_connect()
+            ->table($table)
+            ->where($column, $value)
+            ->where('tenant_id', $tenantId)
+            ->countAllResults();
+
+        return $count > 0;
+    }
+}

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -57,7 +57,7 @@ class PostsApiTest extends CIUnitTestCase
         // 테스트용 포스트 데이터
         $this->testPost = [
             'tenant_id'   => $this->tenant->id,
-            'category_id' => 1,
+            'category_id' => $this->createOtherCategory($this->tenant->id),
             'title'       => '테스트 포스트',
             'slug'        => 'test-post',
             'content'     => '테스트 포스트 내용입니다.',
@@ -407,7 +407,7 @@ class PostsApiTest extends CIUnitTestCase
 
         $fabricator = new Fabricator(PostModel::class);
         $post = $fabricator->setOverrides([
-            'state'    => PostState::PUBLISHED->value,
+            'state'     => PostState::PUBLISHED->value,
             'tenant_id' => $this->tenant->id,
         ])->create();
 
@@ -555,7 +555,7 @@ class PostsApiTest extends CIUnitTestCase
                 'content'     => '테스트 포스트 내용입니다.',
                 'excerpt'     => '포스트 요약',
                 'status'      => 'draft',
-                'category_id' => 1,
+                'category_id' => $this->testPost['category_id'],
                 'tags'        => [$tag[0]->id, $tag[0]->id]
             ]);
 
@@ -1049,7 +1049,7 @@ class PostsApiTest extends CIUnitTestCase
         $draftPost = (new Fabricator(PostModel::class))
             ->setOverrides([
                 'tenant_id' => $this->tenant->id,
-                'state' => PostState::DRAFT->value,
+                'state'     => PostState::DRAFT->value,
             ])->create();
 
         $result = $this->withHeaders($this->getHeaders())
@@ -1068,7 +1068,65 @@ class PostsApiTest extends CIUnitTestCase
         $this->markTestIncomplete('POST comments endpoint not fully implemented yet');
     }
 
+    /**
+     * @test
+     * POST /api/v1/posts
+     */
+    public function test_create_post_rejects_other_tenant_category_id(): void
+    {
+        $otherTenantId = $this->createOtherTenant();
+        $otherCategoryId = $this->createOtherCategory($otherTenantId);
+
+        $this->loginAsAdmin();
+
+        $response = $this->withHeaders($this->getHeaders())
+            ->withBodyFormat('json')
+            ->post('/api/v1/posts', [
+                'title'       => 'Test Post',
+                'content'     => 'This is a test post.',
+                'category_id' => $otherCategoryId,
+            ]);
+
+        $response->assertStatus(422);
+
+        $json = json_decode($response->getJSON(), true);
+        $this->assertArrayHasKey('category_id', $json['errors'] ?? []);
+    }
+
+    /**
+     * @test
+     * PUT /api/v1/posts/{id}
+     */
+    public function test_update_post_rejects_other_tenant_category_id(): void
+    {
+        $otherTenantId = $this->createOtherTenant();
+        $otherCategoryId = $this->createOtherCategory($otherTenantId);
+
+        $this->loginAsAdmin();
+
+        $postId = $this->createTestPost();
+
+        $response = $this->withHeaders($this->getHeaders())
+            ->withBodyFormat('json')
+            ->put("/api/v1/posts/{$postId}", [
+                'title'       => 'Updated Test Post',
+                'content'     => 'This is an updated test post.',
+                'category_id' => $otherCategoryId,
+            ]);
+
+        $response->assertStatus(422);
+    }
+
     // Helper Methods
+
+    protected function createOtherCategory(int $tenantId): int
+    {
+        $otherCategory = (new Fabricator(CategoryModel::class))
+            ->setOverrides(['tenant_id' => $tenantId])
+            ->create();
+
+        return $otherCategory->id;
+    }
 
     /**
      * Admin 권한으로 로그인
@@ -1152,7 +1210,8 @@ class PostsApiTest extends CIUnitTestCase
         // 게시글 생성
         $fabricator = new Fabricator(PostModel::class);
         $post = $fabricator->setOverrides([
-            'writer_id' => $owner->id,
+            'writer_id'   => $owner->id,
+            'category_id' => $this->testPost['category_id'],
         ])->create();
 
         return [$loginUser, $post];

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -1115,6 +1115,9 @@ class PostsApiTest extends CIUnitTestCase
             ]);
 
         $response->assertStatus(422);
+
+        $json = json_decode($response->getJSON(), true);
+        $this->assertArrayHasKey('category_id', $json['errors'] ?? []);
     }
 
     // Helper Methods


### PR DESCRIPTION
## Summary

- `is_not_unique_in_tenant[table.column]` 커스텀 Validation Rule 신규 작성 — 인증된 유저의 tenant_id 스코프 내에서 해당 레코드 존재 여부 검증
- `PostsController::create` / `update`의 `category_id` 검증 룰을 `is_not_unique[categories.id]` → `is_not_unique_in_tenant[categories.id]`로 교체
- PostsApiTest에 타 테넌트 category_id 거부 케이스 2건 추가 (create/update), setUp 회귀 픽스 포함

Closes #135

## 결정사항

- **룰 이름**: `is_not_unique_in_tenant` (이슈 본문 제안 채택)
- **에러 메시지**: 룰 메서드 내 `$error` 할당 대신 언어 파일(`app/Language/en/Validation.php`) 등록 — CI4 표준 + i18n 확장성
- **tags cross-tenant 검증**: 이번 #135 스코프에서 의도적으로 제외 (category_id만 좁게 처리). 향후 별도 이슈로 판단

## 부채 / 남은 작업

- **#138**: `PostModel::fake()`의 `category_id => 1` 하드코딩 근본 정리 — 이번 PR에선 테스트 호출부 `setOverrides`로 우회, 다음 fake 정리 묶음(#110/#136/#138)에서 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 게시물 생성 및 편집 시 카테고리 검증이 현재 테넌트 내의 카테고리로만 제한되도록 개선

* **테스트**
  * 다른 테넌트의 카테고리로 게시물을 생성 및 편집할 수 없음을 확인하는 검증 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/139)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->