### PR TITLE
🐛 fix: CategoriesController permission → apipermission 전환 (#104)

### DIFF
--- a/app/Controllers/Api/V1/CategoriesController.php
+++ b/app/Controllers/Api/V1/CategoriesController.php
@@ -57,7 +57,7 @@ class CategoriesController extends BaseApiController
     }
 
     #[Filter(by: 'tokens')]
-    #[Filter(by: 'permission', having: ['categories.manage'])]
+    #[Filter(by: 'apipermission', having: ['categories.manage'])]
     public function create(): ResponseInterface
     {
         $payload = $this->request->getJSON(true);
@@ -91,7 +91,7 @@ class CategoriesController extends BaseApiController
     }
 
     #[Filter(by: 'tokens')]
-    #[Filter(by: 'permission', having: ['categories.manage'])]
+    #[Filter(by: 'apipermission', having: ['categories.manage'])]
     public function update($id = null): ResponseInterface
     {
         $category = $this->model
@@ -133,7 +133,7 @@ class CategoriesController extends BaseApiController
     }
 
     #[Filter(by: 'tokens')]
-    #[Filter(by: 'permission', having: ['categories.manage'])]
+    #[Filter(by: 'apipermission', having: ['categories.manage'])]
     public function delete($id = null): ResponseInterface
     {
         $category = $this->model


### PR DESCRIPTION
## Summary

- `CategoriesController`의 `create/update/delete` 어트리뷰트를 `permission` → `apipermission`으로 전환
- #68에서 `ApiPermissionFilter` 도입 시 누락된 잔여분 처리
- 권한 실패 시 302 리다이렉트 대신 403 JSON 응답 반환

## 변경 사항

`app/Controllers/Api/V1/CategoriesController.php` 60/94/136 라인

```diff
- #[Filter(by: 'permission', having: ['categories.manage'])]
+ #[Filter(by: 'apipermission', having: ['categories.manage'])]
```

## 검증

- ✅ `vendor/bin/phpunit tests/api/CategoriesApiTest.php` — 10 tests, 21 assertions
- ✅ `vendor/bin/phpunit tests/api/CommentsApiTest.php` — 19 tests, 73 assertions (회귀 없음)
- `CommentsController`는 이미 `apipermission` 적용 완료 상태로 확인됨

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* API 카테고리 관리 기능에 대한 권한 검증 시스템이 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/140)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->