### PR TITLE
♻️ refactor: fake() 정리 묶음 — Tenant/Tag/Post (#110 #136 #138)

### DIFF
--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -71,13 +71,22 @@ class PostModel extends Model
      */
     public function fake(Generator &$faker): array
     {
+        $tenantId = service('tenant')->getId() ?? 1;
+        $categoryId = $this->db
+            ->table('categories')
+            ->where('tenant_id', $tenantId)
+            ->select('id')
+            ->limit(1)
+            ->get()
+            ->getRow('id');
+
         return [
             'title'       => $faker->sentence,
             'content'     => $faker->paragraph,
             'state'       => $faker->randomElement(['draft', 'published']),
-            'category_id' => 1,
+            'category_id' => $categoryId ?? 1,
             'writer_id'   => 1,
-            'tenant_id'   => service('tenant')->getId() ?? 1,
+            'tenant_id'   => $tenantId,
         ];
     }
 

--- a/app/Models/TagModel.php
+++ b/app/Models/TagModel.php
@@ -46,8 +46,8 @@ class TagModel extends Model
     public function fake(Generator &$faker): array
     {
         return [
-            'tenant_id' => 1,
-            'name'      => $faker->unique()->words(2, true),
+            'tenant_id' => service('tenant')->getId() ?? 1,
+            'name'      => "{$faker->unique()->word}-{$faker->randomNumber(4)}",
         ];
     }
 }

--- a/app/Models/TenantModel.php
+++ b/app/Models/TenantModel.php
@@ -2,18 +2,19 @@
 
 namespace App\Models;
 
-use CodeIgniter\Model;
 use App\Entities\TenantEntity;
+use CodeIgniter\Model;
+use Faker\Generator;
 
 class TenantModel extends Model
 {
-    protected $table            = 'tenants';
-    protected $primaryKey       = 'id';
+    protected $table = 'tenants';
+    protected $primaryKey = 'id';
     protected $useAutoIncrement = true;
-    protected $returnType       = TenantEntity::class;
-    protected $useSoftDeletes   = false;
-    protected $protectFields    = true;
-    protected $allowedFields    = ['subdomain', 'name'];
+    protected $returnType = TenantEntity::class;
+    protected $useSoftDeletes = false;
+    protected $protectFields = true;
+    protected $allowedFields = ['subdomain', 'name'];
 
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;
@@ -23,28 +24,36 @@ class TenantModel extends Model
 
     // Dates
     protected $useTimestamps = true;
-    protected $dateFormat    = 'datetime';
-    protected $createdField  = 'created_at';
-    protected $updatedField  = 'updated_at';
-    protected $deletedField  = 'deleted_at';
+    protected $dateFormat = 'datetime';
+    protected $createdField = 'created_at';
+    protected $updatedField = 'updated_at';
+    protected $deletedField = 'deleted_at';
 
     // Validation
-    protected $validationRules      = [
+    protected $validationRules = [
         'subdomain' => 'required|alpha_dash|min_length[3]|max_length[50]|is_unique[tenants.subdomain,id,{id}]',
-        'name' =>'required',
+        'name'      => 'required',
     ];
-    protected $validationMessages   = [];
-    protected $skipValidation       = false;
+    protected $validationMessages = [];
+    protected $skipValidation = false;
     protected $cleanValidationRules = true;
 
     // Callbacks
     protected $allowCallbacks = true;
-    protected $beforeInsert   = [];
-    protected $afterInsert    = [];
-    protected $beforeUpdate   = [];
-    protected $afterUpdate    = [];
-    protected $beforeFind     = [];
-    protected $afterFind      = [];
-    protected $beforeDelete   = [];
-    protected $afterDelete    = [];
+    protected $beforeInsert = [];
+    protected $afterInsert = [];
+    protected $beforeUpdate = [];
+    protected $afterUpdate = [];
+    protected $beforeFind = [];
+    protected $afterFind = [];
+    protected $beforeDelete = [];
+    protected $afterDelete = [];
+
+    public function fake(Generator &$faker): array
+    {
+        return [
+            'subdomain' => "{$faker->unique()->word}-{$faker->randomNumber(4)}",
+            'name'      => $faker->company,
+        ];
+    }
 }

--- a/tests/api/CategoriesApiTest.php
+++ b/tests/api/CategoriesApiTest.php
@@ -37,9 +37,7 @@ class CategoriesApiTest extends CIUnitTestCase
 
         $this->resetServices();
 
-        $this->tenant = (new Fabricator(TenantModel::class))
-            ->setOverrides(['subdomain' => 'test-tenant-' . uniqid()])
-            ->create();
+        $this->tenant = (new Fabricator(TenantModel::class))->create();
 
         $this->category = (new Fabricator(CategoryModel::class))
             ->setOverrides(['tenant_id' => $this->tenant->id])
@@ -229,9 +227,7 @@ class CategoriesApiTest extends CIUnitTestCase
     // Helper Methods
     private function createOtherTenant(): int
     {
-        $tenant = (new Fabricator(TenantModel::class))
-            ->setOverrides(['subdomain' => 'other-tenant-' . uniqid()])
-            ->create();
+        $tenant = (new Fabricator(TenantModel::class))->create();
 
         return $tenant->id;
     }

--- a/tests/api/CommentsApiTest.php
+++ b/tests/api/CommentsApiTest.php
@@ -56,9 +56,7 @@ class CommentsApiTest extends CIUnitTestCase
 
         $this->resetServices();
 
-        $this->tenant = (new Fabricator(TenantModel::class))
-            ->setOverrides(['subdomain' => 'test-tenant-' . uniqid()])
-            ->create();
+        $this->tenant = (new Fabricator(TenantModel::class))->create();
 
         $userModel = auth()->getProvider();
         $admin = $userModel->findByCredentials(['email' => 'admin@example.com']);
@@ -453,9 +451,7 @@ class CommentsApiTest extends CIUnitTestCase
     // Helper Methods
     private function createTenant(): int
     {
-        $tenant = (new Fabricator(TenantModel::class))
-            ->setOverrides(['subdomain' => 'other-tenant-' . uniqid()])
-            ->create();
+        $tenant = (new Fabricator(TenantModel::class))->create();
 
         return $tenant->id;
     }

--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -42,9 +42,7 @@ class PostsApiTest extends CIUnitTestCase
 
         $this->resetServices();
 
-        $this->tenant = (new Fabricator(TenantModel::class))
-            ->setOverrides(['subdomain' => 'test-tenant-' . uniqid()])
-            ->create();
+        $this->tenant = (new Fabricator(TenantModel::class))->create();
 
         // PostModel::fake() 등 fabricate가 service('tenant')를 참조하도록 미리 세팅
         service('tenant')->setTenant($this->tenant);
@@ -1242,9 +1240,7 @@ class PostsApiTest extends CIUnitTestCase
 
     private function createOtherTenant(): int
     {
-        $tenant = (new Fabricator(TenantModel::class))
-            ->setOverrides(['subdomain' => 'other-tenant-' . uniqid()])
-            ->create();
+        $tenant = (new Fabricator(TenantModel::class))->create();
 
         return $tenant->id;
     }


### PR DESCRIPTION
## Summary

세 모델의 `fake()` 메서드를 정리하여 cross-tenant 정합성과 검증 룰 통과를 보장하고, 호출부의 우회 `setOverrides`를 제거.

## 변경 사항

### 모델 fake() 정리
- **TenantModel** (#136): `fake()` 메서드 신규 추가
  - `subdomain`: `"{$faker->unique()->word}-{$faker->randomNumber(4)}"` — `alpha_dash` + `min_length[3]` + unique 보장
  - `name`: `$faker->company`
- **TagModel** (#110):
  - `tenant_id`: `1` 하드코딩 → `service('tenant')->getId() ?? 1` (PostModel 패턴 일관성)
  - `name`: `$faker->unique()->words(2, true)` → `"{$faker->unique()->word}-{$faker->randomNumber(4)}"` (풀 고갈 회피 + min_length 보장)
- **PostModel** (#138):
  - `category_id`: `1` 하드코딩 → 현재 tenant 소속 카테고리 동적 lookup (없으면 fallback `1`)
  - `$tenantId` 변수 분리로 `service('tenant')->getId()` 중복 호출 제거

### 호출부 정리 (6곳)
- `tests/api/PostsApiTest.php` setUp + `createOtherTenant()`
- `tests/api/CategoriesApiTest.php` setUp + `createOtherTenant()`
- `tests/api/CommentsApiTest.php` setUp + `createTenant()`

→ 모두 `setOverrides(['subdomain' => 'test-tenant-' . uniqid()])` 우회 제거. fake()에서 unique subdomain을 자체 보장.

## 주요 결정

- **fake() 안에서 다른 모델의 fake()를 호출하지 않음**: cross-model side effect 방지. tenant context는 테스트 setUp에서 명시적으로 한 번만 Fabricate + `service('tenant')->setTenant()` 패턴 유지
- **`category_id` 동적 lookup**: 시드/Fabricate된 첫 카테고리를 찾되 fallback `1` 유지 (테넌트별 카테고리 없는 엣지 케이스 대비)
- **`writer_id` 하드코딩 1은 이번 스코프 밖**: 별도 이슈 필요 시 분리

## 검증

- ✅ `vendor/bin/paratest --functional` — 205 tests, 478 assertions, Incomplete 1 (의도된 markTestIncomplete)
- ✅ subdomain 우회 setOverrides 잔여 0건

Closes #110
Closes #136
Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 더미 데이터 생성 로직을 개선하여 하드코딩된 값 대신 동적으로 필요한 데이터를 조회하도록 변경했습니다.
  * 테스트 데이터 생성 방식을 정규화하여 일관성 있는 테스트 환경을 구성했습니다.

* **Chores**
  * 코드 스타일 및 타입 선언을 개선하여 가독성을 향상했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/141)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->