### PR TITLE
♻️ refactor: PostModel::fake() ?? 1 fallback 제거 및 category 명시 강제 (#142)

### DIFF
--- a/app/Models/CommentModel.php
+++ b/app/Models/CommentModel.php
@@ -39,7 +39,21 @@ class CommentModel extends Model
 
     public function fake(Generator &$faker): array
     {
-        $post = (new Fabricator(PostModel::class))->create();
+        $tenant = (new Fabricator(TenantModel::class))->create();
+
+        $category = (new Fabricator(CategoryModel::class))
+            ->setOverrides([
+                'tenant_id' => $tenant->id,
+            ])
+            ->create();
+
+        $post = (new Fabricator(PostModel::class))
+            ->setOverrides([
+                'tenant_id' => $tenant->id,
+                'category_id' => $category->id,
+            ])
+            ->create();
+
         $user = (new Fabricator(UserModel::class))->create();
 
         return [

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -84,7 +84,7 @@ class PostModel extends Model
             'title'       => $faker->sentence,
             'content'     => $faker->paragraph,
             'state'       => $faker->randomElement(['draft', 'published']),
-            'category_id' => $categoryId ?? 1,
+            'category_id' => $categoryId,
             'writer_id'   => 1,
             'tenant_id'   => $tenantId,
         ];

--- a/tests/api/CommentsApiTest.php
+++ b/tests/api/CommentsApiTest.php
@@ -7,6 +7,7 @@ use App\Entities\CommentEntity;
 use App\Entities\PostEntity;
 use App\Enums\CommentState;
 use App\Enums\PostState;
+use App\Models\CategoryModel;
 use App\Models\CommentModel;
 use App\Models\PostModel;
 use App\Models\TenantModel;
@@ -38,6 +39,7 @@ class CommentsApiTest extends CIUnitTestCase
     protected $refresh = true;
     protected $post;
     protected $tenant;
+    protected $category;
 
     /**
      * @return string[]
@@ -57,6 +59,11 @@ class CommentsApiTest extends CIUnitTestCase
         $this->resetServices();
 
         $this->tenant = (new Fabricator(TenantModel::class))->create();
+        $this->category = (new Fabricator(CategoryModel::class))
+            ->setOverrides([
+                'tenant_id' => $this->tenant->id,
+            ])
+            ->create();
 
         $userModel = auth()->getProvider();
         $admin = $userModel->findByCredentials(['email' => 'admin@example.com']);
@@ -64,8 +71,9 @@ class CommentsApiTest extends CIUnitTestCase
 
         $this->post = (new Fabricator(PostModel::class))
             ->setOverrides([
-                'state'     => PostState::PUBLISHED->value,
-                'tenant_id' => $this->tenant->id,
+                'state'       => PostState::PUBLISHED->value,
+                'tenant_id'   => $this->tenant->id,
+                'category_id' => $this->category->id,
             ])
             ->create();
     }
@@ -436,10 +444,17 @@ class CommentsApiTest extends CIUnitTestCase
     public function test_posts_comments_isolates_other_tenant(): void
     {
         $otherTenantId = $this->createTenant();
+
+        $category = (new Fabricator(CategoryModel::class))
+            ->setOverrides([
+                'tenant_id' => $otherTenantId
+            ])->create();
+
         $otherPost = (new Fabricator(PostModel::class))
             ->setOverrides([
-                'tenant_id' => $otherTenantId,
-                'state'     => PostState::PUBLISHED->value,
+                'tenant_id'   => $otherTenantId,
+                'category_id' => $category->id,
+                'state'       => PostState::PUBLISHED->value,
             ])->create();
 
         $result = $this->withHeaders($this->getHeaders())
@@ -605,7 +620,12 @@ class CommentsApiTest extends CIUnitTestCase
         $pending = $fab->setOverrides(['post_id' => $postId, 'state' => CommentState::PENDING->value])->create();
 
         /** @var PostEntity $otherPost */
-        $otherPost = (new Fabricator(PostModel::class))->create();
+        $otherPost = (new Fabricator(PostModel::class))
+            ->setOverrides([
+                'tenant_id'   => $this->tenant->id,
+                'category_id' => $this->category->id,
+            ])
+            ->create();
 
         /** @var CommentEntity $anotherPost */
         $anotherPost = $fab->setOverrides(['post_id' => $otherPost->id, 'state' => CommentState::APPROVED->value])->create();


### PR DESCRIPTION
## Summary

- `PostModel::fake()`에서 `category_id ?? 1` fallback 제거 — `null` 전달 시 DB 제약조건 위반으로 즉시 실패하도록 변경
- `CommentModel::fake()`에서 Tenant → Category → Post 순서로 fabricate 후 `setOverrides`로 `tenant_id`/`category_id`를 명시적으로 전달 (결정성 보장)
- `CommentsApiTest`에서 `$this->category` 인스턴스 변수를 `setUp`에 노출하고, Post fabricate 시 `category_id` 명시. `test_posts_comments_isolates_other_tenant`와 `createMixedScenario` 두 곳도 동일하게 정리

## 결정

- `?? 1` 은 "존재하지 않을 수도 있는 row에 조용히 의존"하는 패턴으로, 제거 후 호출부 강제가 맞음
- `CommentModel::fake()` 내부에서 Tenant/Category를 직접 fabricate — fake()는 독립 실행 가능해야 하므로 내부에서 픽스처를 생성하는 것이 올바른 방향

## 부채 / 남은 작업

- `CategoryModel::fake()`의 `tenant_id => 1` 하드코딩 — PR #141 패턴(`service('tenant')->getId() ?? 1`)으로 정리 가능하나 이번 스코프 밖. 별도 이슈 검토 예정
- `PostsApiTest:1031`의 cross-tenant 카테고리 차용 — INSERT는 성공하므로 회귀 없음. 별도 이슈 분리 검토 예정

## 테스트

`vendor/bin/paratest --no-coverage` 전체 통과
- Tests: 205, Assertions: 478, Incomplete: 1 (기존), Failures: 0 / 46.8s

Closes #142

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 댓글, 게시글, 카테고리 간 관계 데이터의 일관성을 개선했습니다.
  * 테넌트별 데이터 격리가 더욱 견고해졌습니다.

* **개선**
  * 내부 데이터 생성 로직을 최적화하여 엔터티 간 종속 관계를 강화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->