### PR TITLE
♻️ refactor: CategoryModel::fake() tenant_id 동적화 (#144)

### DIFF
--- a/app/Models/CategoryModel.php
+++ b/app/Models/CategoryModel.php
@@ -44,7 +44,6 @@ class CategoryModel extends Model
     protected $beforeUpdate = ['generateSlug'];
 
 
-
     /**
      * fake Category 모델 인스턴스 반환
      *
@@ -54,8 +53,8 @@ class CategoryModel extends Model
     public function fake(Generator $faker): CategoryEntity
     {
         return new CategoryEntity([
-            'tenant_id' => 1,
-            'name'      => $faker->word,
+            'tenant_id' => service('tenant')->getId() ?? 1,
+            'name'      => "{$faker->unique()->word}-{$faker->randomNumber(4)}",
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- PR #141 패턴(`service('tenant')->getId() ?? 1`)을 `CategoryModel::fake()`에 적용
- 보너스: `name`도 `unique()-randomNumber(4)` 패턴 정렬 — `(tenant_id, name)` unique key 충돌 방지

## 결정 / 관찰
호출부 7곳 검토 결과 모두 **변경 없음**:
- `CategoriesApiTest:42, 216` — setUp(컨텍스트 미세팅) / cross-tenant 의도, override 유지
- `CommentsApiTest:62, 448` — 동일
- `PostsApiTest:1125` — 헬퍼 `createOtherCategory($tenantId)`, 호출부 의도 보존 위해 override 유지
- `CommentModel::fake():44` — 자체 완결 그래프(tenant→category→post) 의도, override 유지
- `PostsApiTest:248, 316` — 원래 `tenant_id` override가 없어 이번 변경으로 **자동 정합성 회복** (이전엔 post=setUp tenant / category=tenant_id 1 cross-tenant 상태로 통과하던 hidden 부채)

## 회귀 확인
- composer test: 205 tests, 478 assertions, all passing (incomplete 1 pre-existing)

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 테스트 데이터 생성 로직을 개선했습니다. 카테고리 생성 시 테넌트 정보를 더욱 안정적으로 처리하고, 카테고리 이름 생성의 유니크성을 강화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->