### PR TITLE
🔒 fix: PostsApiTest test_show_post otherPost 픽스처 cross-tenant 정합성 (#145)

### DIFF
--- a/tests/api/PostsApiTest.php
+++ b/tests/api/PostsApiTest.php
@@ -1026,19 +1026,19 @@ class PostsApiTest extends CIUnitTestCase
      */
     public function test_show_post_isolates_other_tenant(): void
     {
-        // 1. 다른 테넌트와 그 소속 published post 생성
         $otherTenantId = $this->createOtherTenant();
+        $otherCategoryId = $this->createOtherCategory($otherTenantId);
+
         $otherPost = (new Fabricator(PostModel::class))
             ->setOverrides([
                 'tenant_id' => $otherTenantId,
+                'category_id' => $otherCategoryId,
                 'state'     => PostState::PUBLISHED->value,
             ])->create();
 
-        // 2. 본인 tenant 헤더로 다른 tenant의 post 조회 시도
         $result = $this->withHeaders($this->getHeaders())
             ->get("/api/v1/posts/{$otherPost->id}");
 
-        // 3. 격리 작동 검증
         $result->assertStatus(404);
     }
 


### PR DESCRIPTION
## Summary
- `test_show_post_isolates_other_tenant`의 `$otherPost`를 `tenant_id` ↔ `category_id` 정합성 있게 fabricate
- `:1100-1105` 패턴 그대로 적용 (`createOtherCategory($otherTenantId)` 호출 후 `category_id` override)
- 부수: 자명한 단계 주석 3개 제거 — 변수명/메서드명에서 의도 자명

## 배경
PR #143 작업 중 발견된 부채. `PostModel::fake()`의 `category_id` lookup이 `service('tenant')->getId()` = setUp tenant 기준이라, `tenant_id=otherTenant` / `category_id=setUp tenant 소속`인 cross-tenant 상태로 INSERT됨. INSERT 자체는 성공해 회귀는 없었으나, "다른 tenant의 post 격리" 검증의 의미를 약화시킴 (운영 코드 #135가 막아야 할 위반의 fixture 버전).

## 검토
`grep -n createOtherTenant tests/api/` 결과 5곳 중 본 케이스만 Post fabricate 시 `category_id` 누락. 나머지는 영향 없음:
- `CategoriesApiTest:214` — Category만 fabricate
- `PostsApiTest:933` — Tag만 fabricate
- `PostsApiTest:1075, 1100` — 이미 `createOtherCategory` 호출

## 회귀 확인
- composer test: 205 tests, 478 assertions, all passing (incomplete 1 pre-existing)

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 테넌트 격리 검증 테스트의 커버리지를 강화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->