### PR TITLE
✨ feat: 테넌트 공개 홈페이지 추가 (#14)

### DIFF
--- a/app/Controllers/Tenant/HomeController.php
+++ b/app/Controllers/Tenant/HomeController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Controllers\Tenant;
+
+use App\Controllers\BaseController;
+
+class HomeController extends BaseController
+{
+    public function index(): string
+    {
+        $tenant = service('tenant')->getTenant();
+
+        return view('tenant/home', compact('tenant'));
+    }
+}

--- a/app/Views/tenant/home.php
+++ b/app/Views/tenant/home.php
@@ -1,0 +1,26 @@
+<?= $this->extend('layouts/default') ?>
+
+<?= $this->section('title') ?>
+
+<?= esc($tenant->name) ?>
+
+<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+<div class="hero min-h-[60vh] bg-base-200">
+    <div class="hero-content text-center">
+        <div class="max-w-2xl">
+            <h1 class="text-5xl">
+                <?= esc($tenant->name) ?>
+            </h1>
+            <p class="py-6 text-nord-4">
+                <?= esc($tenant->subdomain) ?>.ci4-cms.test 에 오신 것을 환영합니다.
+            </p>
+            <a href="/<?= esc($tenant->subdomain, 'url') ?>/posts" class="btn btn-primary">
+                포스트 보기
+            </a>
+        </div>
+    </div>
+</div>
+<?= $this->endSection() ?>
+

--- a/app/Views/tenant/home.php
+++ b/app/Views/tenant/home.php
@@ -14,9 +14,9 @@
                 <?= esc($tenant->name) ?>
             </h1>
             <p class="py-6 text-nord-4">
-                <?= esc($tenant->subdomain) ?>.ci4-cms.test 에 오신 것을 환영합니다.
+                <?= esc(site_url($tenant->subdomain)) ?>에 오신 것을 환영합니다.
             </p>
-            <a href="/<?= esc($tenant->subdomain, 'url') ?>/posts" class="btn btn-primary">
+            <a href="<?= esc(site_url($tenant->subdomain . '/posts'), 'attr') ?>" class="btn btn-primary">
                 포스트 보기
             </a>
         </div>

--- a/tests/feature/TenantHomeTest.php
+++ b/tests/feature/TenantHomeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\TenantModel;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\FeatureTestTrait;
+
+class TenantHomeTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+    use FeatureTestTrait;
+
+    protected $refresh = true;
+    protected $namespace = 'App';
+
+    public function test_existing_tenant_home_renders(): void
+    {
+        $tenant = fake(TenantModel::class, [
+            'subdomain' => 'acme',
+            'name' => 'Acme Inc.'
+        ]);
+
+        $result = $this->get("/{$tenant->subdomain}");
+
+        $result->assertStatus(200);
+        $result->assertSee('Acme Inc.');
+    }
+
+    public function test_unknown_tenant_returns_404(): void
+    {
+        $result = $this->get('/nonexistent-tenant-xyz');
+        $result->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## Summary

#14 프론트엔드 공개 페이지 첫 단추로 **테넌트 공개 홈페이지** 1개만 구현.

- `Tenant\HomeController::index` — `TenantFilter`가 이미 `service('tenant')`에 컨텍스트를 넣어주므로, 라우트의 `$1` 슬러그를 받지 않고 서비스에서 꺼내 씀
- `app/Views/tenant/home.php` — 별도 테넌트 레이아웃을 만들지 않고 기존 `layouts/default` 재활용 (DaisyUI hero 컴포넌트)
- `tests/feature/TenantHomeTest.php` — 존재하는 슬러그(200), 미존재 슬러그(404) 2건

## 결정사항

- **테넌트 전용 레이아웃 미도입**: 첫 PR 단위를 작게 잡기 위해 `layouts/default`를 그대로 extend. 공개 페이지 네비/푸터 분리 필요성이 명확해지면 후속 PR에서 분리
- **라우트 슬러그 인자 미수신**: `TenantFilter`가 컨텍스트를 보장하므로 컨트롤러는 `service('tenant')->getTenant()`만 사용 → 컨트롤러가 라우트 형식에 결합되지 않음

## 남은 작업 (#14 후속 PR로 분리)

- [ ] 포스트 목록 페이지 (`Tenant\PostsController::index`)
- [ ] 포스트 상세 페이지 (`Tenant\PostsController::show`)
- [ ] 카테고리별/태그별 포스트 목록
- [ ] 검색 결과 페이지
- [ ] 페이지네이션 UI
- [ ] 댓글 표시 UI
- [ ] sitemap.xml / robots.txt

Closes part of #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 테넌트별 홈 페이지 기능 추가

* **Tests**
  * 테넌트 홈 페이지 렌더링 및 404 에러 처리에 대한 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->