### PR TITLE
✨ feat: 테넌트 공개 포스트 목록 페이지 추가 (#14)

### DIFF
--- a/app/Controllers/Tenant/PostsController.php
+++ b/app/Controllers/Tenant/PostsController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Controllers\Tenant;
+
+use App\Controllers\BaseController;
+use App\Enums\PostState;
+use App\Models\PostModel;
+
+class PostsController extends BaseController
+{
+    public function index(): string
+    {
+        $tenantService = service('tenant');
+
+        $model = model(PostModel::class);
+        $posts = $model
+            ->where('tenant_id', $tenantService->getId())
+            ->where('state', PostState::PUBLISHED->value)
+            ->orderBy('created_at', 'DESC')
+            ->paginate(10);
+
+        return view('tenant/posts/index', [
+            'tenant' => $tenantService->getTenant(),
+            'posts'  => $posts,
+            'pager'  => $model->pager,
+        ]);
+    }
+}

--- a/app/Views/tenant/posts/index.php
+++ b/app/Views/tenant/posts/index.php
@@ -1,0 +1,43 @@
+<?= $this->extend('layouts/default') ?>
+
+<?= $this->section('title') ?>
+포스트 - <?= esc($tenant->name) ?>
+<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+<div class="container mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold mb-8 text-nord-8">
+        <?= esc($tenant->name) ?> 포스트
+    </h1>
+
+    <?php if (empty($posts)): ?>
+        <div class="alert alert-info">아직 발행된 포스트가 없습니다.</div>
+    <?php else: ?>
+        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            <?php foreach ($posts as $post): ?>
+                    <article class="card bg-base-100 shadow-nord">
+                    <div class="card-body">
+                        <h2 class="card-title text-nord-7">
+                            <?= esc($post->title) ?>
+                        </h2>
+                        <p class="text-sm text-nord-4">
+                            <?= esc(date('Y-m-d', strtotime($post->created_at))) ?>
+                        </p>
+                        <p class="line-clamp-3">
+                            <?= esc(mb_substr(strip_tags($post->content), 0, 120)) ?>
+                        </p>
+                        <div class="card-actions justify-end">
+                            <a href="<?= esc(site_url("{$tenant->subdomain}/posts/{$post->slug}"), 'attr') ?>"
+                                class="btn btn-sm btn-primary">읽기</a>
+                        </div>
+                    </div>
+                    </article>
+            <?php endforeach; ?>
+        </div>
+
+        <div class="mt-10 flex justify-center">
+            <?= $pager->links('default', 'default_full') ?>
+        </div>
+    <?php endif; ?>
+</div>
+<?= $this->endSection() ?>

--- a/tests/feature/TenantHomeTest.php
+++ b/tests/feature/TenantHomeTest.php
@@ -13,7 +13,7 @@ class TenantHomeTest extends CIUnitTestCase
     use FeatureTestTrait;
 
     protected $refresh = true;
-    protected $namespace = 'App';
+    protected $namespace = null;
 
     public function test_existing_tenant_home_renders(): void
     {

--- a/tests/feature/TenantPostsListTest.php
+++ b/tests/feature/TenantPostsListTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Database\Seeds\TestSeeder;
+use App\Enums\PostState;
+use App\Models\CategoryModel;
+use App\Models\PostModel;
+use App\Models\TenantModel;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\FeatureTestTrait;
+
+class TenantPostsListTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+    use FeatureTestTrait;
+
+    protected $refresh = true;
+    protected $namespace = null;
+    protected $seed = TestSeeder::class;
+
+    public function test_lists_only_published_posts_of_current_tenant(): void
+    {
+        $tenant = fake(TenantModel::class, ['subdomain' => 'acme', 'name' => 'Acme']);
+        service('tenant')->setTenant($tenant);
+        $category = fake(CategoryModel::class, ['tenant_id' => $tenant->id]);
+
+        fake(PostModel::class, [
+            'tenant_id'   => $tenant->id,
+            'category_id' => $category->id,
+            'title'       => '공개 포스트',
+            'state'       => PostState::PUBLISHED->value,
+        ]);
+
+        fake(PostModel::class, [
+            'tenant_id'   => $tenant->id,
+            'category_id' => $category->id,
+            'title'       => '비공개 포스트',
+            'state'       => PostState::DRAFT->value,
+        ]);
+
+        $result = $this->get("/{$tenant->subdomain}/posts");
+
+        $result->assertStatus(200);
+        $result->assertSee('공개 포스트');
+        $result->assertDontSee('비공개 포스트');
+    }
+
+    public function test_isolates_other_tenant_posts(): void
+    {
+        $tenantA = fake(TenantModel::class, ['subdomain' => 'a-co']);
+        $tenantB = fake(TenantModel::class, ['subdomain' => 'b-co']);
+
+        service('tenant')->setTenant($tenantB);
+        $categoryB = fake(CategoryModel::class, ['tenant_id' => $tenantB->id]);
+        fake(PostModel::class, [
+            'tenant_id'   => $tenantB->id,
+            'category_id' => $categoryB->id,
+            'title'       => 'B사 포스트',
+            'state'       => PostState::PUBLISHED->value,
+        ]);
+
+        $result = $this->get("/{$tenantA->subdomain}/posts");
+
+        $result->assertStatus(200);
+        $result->assertDontSee('B사 포스트');
+    }
+
+    public function test_empty_list_renders_placeholder(): void
+    {
+        $tenant = fake(TenantModel::class, ['subdomain' => 'empty-co']);
+
+        $result = $this->get("/{$tenant->subdomain}/posts");
+
+        $result->assertStatus(200);
+        $result->assertSee('아직 발행된 포스트가 없습니다');
+    }
+}

--- a/tests/feature/TenantPostsListTest.php
+++ b/tests/feature/TenantPostsListTest.php
@@ -52,6 +52,15 @@ class TenantPostsListTest extends CIUnitTestCase
         $tenantA = fake(TenantModel::class, ['subdomain' => 'a-co']);
         $tenantB = fake(TenantModel::class, ['subdomain' => 'b-co']);
 
+        service('tenant')->setTenant($tenantA);
+        $categoryA = fake(CategoryModel::class, ['tenant_id' => $tenantA->id]);
+        fake(PostModel::class, [
+            'tenant_id'   => $tenantA->id,
+            'category_id' => $categoryA->id,
+            'title'       => 'A사 포스트',
+            'state'       => PostState::PUBLISHED->value,
+        ]);
+
         service('tenant')->setTenant($tenantB);
         $categoryB = fake(CategoryModel::class, ['tenant_id' => $tenantB->id]);
         fake(PostModel::class, [
@@ -64,6 +73,7 @@ class TenantPostsListTest extends CIUnitTestCase
         $result = $this->get("/{$tenantA->subdomain}/posts");
 
         $result->assertStatus(200);
+        $result->assertSee('A사 포스트');
         $result->assertDontSee('B사 포스트');
     }
 


### PR DESCRIPTION
## Summary

#14 프론트엔드 공개 페이지 2차 — 테넌트별 **포스트 목록 페이지** (`/{tenant}/posts`).

- `Tenant\PostsController::index` — `service('tenant')->getId()` + `state=published` 필터, `paginate(10)` 고정
- `app/Views/tenant/posts/index.php` — DaisyUI 카드 그리드 + 빈 목록 placeholder + `$pager->links('default', 'default_full')`
- `TenantPostsListTest` — 3 케이스 (published만 표시 / 다른 테넌트 격리 / 빈 목록)

부수: `TenantHomeTest`의 `$namespace`를 `'App'` → `null`로 변경 (Shield 마이그레이션 포함, 향후 인증 관련 추가 시 폭발 예방)

## 결정사항

- **`paginate(10)` 고정**: API는 동적 per_page 받지만, 공개 페이지는 고정값이 SEO/캐싱 친화적
- **테스트 픽스처 패턴**: `$seed = TestSeeder::class` + `category_id` 명시 (#142/#143 fallback 제거 정책의 호출자 책임)
- **컨트롤러 클래스명**: API와 동일하게 복수형 `PostsController` (라우트가 이미 그렇게 지정됨)
- **페이저 템플릿은 기본**: DaisyUI 스타일 페이저는 후속 PR — 일단 작동 검증 우선

## 남은 작업 (#14 후속 PR로 분리)

- [ ] 포스트 상세 페이지 (`Tenant\PostsController::show`)
- [ ] 카테고리별/태그별 포스트 목록
- [ ] 검색 결과 페이지
- [ ] DaisyUI 스타일 페이저 (커스텀 템플릿)
- [ ] 댓글 표시 UI
- [ ] sitemap.xml / robots.txt

Closes part of #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 테넌트별 게시물 목록 페이지 추가 — 현재 테넌트의 발행 게시물만 카드 그리드로 표시
  * 게시물 카드에 제목·작성일·본문 요약 표시, 테넌트별(하위도메인) 링크 및 페이지 매김 제공
  * 게시물이 없을 때 안내 메시지 표시

* **테스트**
  * 테넌트별 게시물 노출·격리 및 빈 목록 플레이스홀더를 검증하는 기능 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->