### PR TITLE
✨ feat: 테넌트 공개 포스트 상세 페이지 추가 (#14)

### DIFF
--- a/app/Controllers/Tenant/PostsController.php
+++ b/app/Controllers/Tenant/PostsController.php
@@ -5,6 +5,7 @@ namespace App\Controllers\Tenant;
 use App\Controllers\BaseController;
 use App\Enums\PostState;
 use App\Models\PostModel;
+use CodeIgniter\Exceptions\PageNotFoundException;
 
 class PostsController extends BaseController
 {
@@ -24,5 +25,23 @@ class PostsController extends BaseController
             'posts'  => $posts,
             'pager'  => $model->pager,
         ]);
+    }
+
+    public function show(string $tenantSlug, string $postSlug): string
+    {
+        $tenant = service('tenant')->getTenant();
+        $model = model(PostModel::class);
+
+        $post = $model
+            ->where('tenant_id', $tenant->id)
+            ->where('slug', $postSlug)
+            ->where('state', PostState::PUBLISHED->value)
+            ->first();
+
+        if ($post === null) {
+            throw PageNotFoundException::forPageNotFound();
+        }
+
+        return view('tenant/posts/show', compact('post', 'tenant'));
     }
 }

--- a/app/Views/tenant/posts/show.php
+++ b/app/Views/tenant/posts/show.php
@@ -1,0 +1,24 @@
+<?= $this->extend('layouts/default') ?>
+
+<?= $this->section('title') ?>
+    <?= esc($post->title) ?> - <?= esc($tenant->name) ?>
+<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+    <div class="container mx-auto px-4 py-10">
+        <h1 class="text-3xl font-bold mb-2">
+            <?= esc($post->title) ?>
+        </h1>
+        <time class="text-sm text-nord-4 mb-6" datetime="<?= esc(date('Y-m-d', strtotime($post->created_at))) ?>">
+            <?= esc(date('Y-m-d', strtotime($post->created_at))) ?>
+        </time>
+
+        <article class="prose max-w-3xl">
+            <?= nl2br(esc($post->content)) ?>
+        </article>
+
+        <a class="btn btn-ghost btn-sm" href="<?= esc(site_url("{$tenant->subdomain}/posts"), 'attr') ?>">
+            ← 포스트 목록으로
+        </a>
+    </div>
+<?= $this->endSection() ?>

--- a/tests/feature/TenantPostsShowTest.php
+++ b/tests/feature/TenantPostsShowTest.php
@@ -46,6 +46,7 @@ class TenantPostsShowTest extends CIUnitTestCase
         $response->assertStatus(200);
         $response->assertSee($post->title);
         $response->assertSee('본문 내용');
+        $response->assertSee(date('Y-m-d', strtotime($post->created_at)));
     }
 
     /**

--- a/tests/feature/TenantPostsShowTest.php
+++ b/tests/feature/TenantPostsShowTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Database\Seeds\TestSeeder;
+use App\Enums\PostState;
+use App\Models\CategoryModel;
+use App\Models\PostModel;
+use App\Models\TenantModel;
+use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\FeatureTestTrait;
+
+class TenantPostsShowTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+    use FeatureTestTrait;
+
+    protected $refresh = true;
+    protected $namespace = null;
+    protected $seed = TestSeeder::class;
+    protected $tenant;
+    protected $category;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tenant = fake(TenantModel::class, ['subdomain' => 'acme', 'name' => 'Acme']);
+        $this->category = fake(CategoryModel::class, ['tenant_id' => $this->tenant->id]);
+        service('tenant')->setTenant($this->tenant);
+    }
+
+    /**
+     * @test
+     * 발행 포스트 → 200 + 제목/본문/날짜 노출 - Happy Path.
+     */
+    public function test_renders_published_post(): void
+    {
+        $post = $this->createPost();
+
+        $path = $this->getPath(tenant: $this->tenant, post: $post);
+        $response = $this->get(path: $path);
+
+        $response->assertStatus(200);
+        $response->assertSee($post->title);
+        $response->assertSee('본문 내용');
+    }
+
+    /**
+     * @test
+     * 존재하지 않는 slug → 404
+     */
+    public function test_returns_404_for_unknown_slug(): void
+    {
+        $this->expectException(PageNotFoundException::class);
+        $this->get("/{$this->tenant->subdomain}/posts/unknown-slug");
+    }
+
+    /**
+     * @test
+     * DRAFT 상태 → 404 (상태 격리)
+     */
+    public function test_returns_404_for_draft_post(): void
+    {
+        $post = $this->createPost(PostState::DRAFT->value);
+
+        $path = $this->getPath(tenant: $this->tenant, post: $post);
+
+        $this->expectException(PageNotFoundException::class);
+        $this->get(path: $path);
+    }
+
+    /**
+     * @test
+     * B사 slug를 A사 URL로 접근 → 404 (테넌트 격리)
+     */
+    public function test_isolates_other_tenant_post(): void
+    {
+        $otherTenant = fake(TenantModel::class, ['subdomain' => 'other-co']);
+        $otherCategory = fake(CategoryModel::class, ['tenant_id' => $otherTenant->id]);
+        $otherPost = fake(PostModel::class, [
+            'tenant_id'   => $otherTenant->id,
+            'category_id' => $otherCategory->id,
+            'title'       => 'Other Post Title',
+            'state'       => PostState::PUBLISHED->value,
+            'content'     => '이것은 다른 테넌트의 게시물입니다.'
+        ]);
+
+        $otherPath = $this->getPath(tenant: $otherTenant, post: $otherPost);
+
+        $response = $this->get(path: $otherPath);
+        $response->assertStatus(200);
+        $response->assertSee('Other Post Title');
+
+        $path = $this->getPath(tenant: $this->tenant, post: $otherPost);
+
+        $this->expectException(PageNotFoundException::class);
+        $this->get(path: $path);
+    }
+
+    /**
+     * @test
+     * XSS 공격 문자열이 본문에 포함되어도 제대로 렌더링
+     */
+    public function test_escapes_xss_in_content(): void
+    {
+        $post = fake(PostModel::class, [
+            'tenant_id'   => $this->tenant->id,
+            'category_id' => $this->category->id,
+            'title'       => 'Test Post Title',
+            'state'       => PostState::PUBLISHED->value,
+            'content'     => '<script>alert(1)</script>안전한본문'
+        ]);
+
+        $path = $this->getPath(tenant: $this->tenant, post: $post);
+
+        $response = $this->get(path: $path);
+
+        $response->assertStatus(200);
+        $response->assertDontSee('<script>alert(1)</script>');
+        $response->assertSee('&lt;script&gt;');
+        $response->assertSee('안전한본문');
+    }
+
+    // helper methods
+    private function createPost(string $state = PostState::PUBLISHED->value): object
+    {
+        return fake(PostModel::class, [
+            'tenant_id'   => $this->tenant->id,
+            'category_id' => $this->category->id,
+            'title'       => 'Test Post Title',
+            'state'       => $state,
+            'content'     => '이것은 본문 내용입니다.'
+        ]);
+    }
+
+    private function getPath(object $tenant, object $post): string
+    {
+        return "/{$tenant->subdomain}/posts/{$post->slug}";
+    }
+}


### PR DESCRIPTION
## Summary

- `PostsController::show(string $tenantSlug, string $postSlug)` 추가 — tenant_id 격리 + PUBLISHED 상태 필터 + slug 조회, 미존재/비공개 시 `PageNotFoundException` throw
- `app/Views/tenant/posts/show.php` 신규 — `layouts/default` 확장, 제목/작성일/본문(`nl2br(esc())`)/목록 백링크, 전체 출력 `esc()` 처리
- `TenantPostsShowTest` 5개 추가: happy path, 존재 않는 slug→404, draft→404, 테넌트 격리(양성+음성 단언), XSS escape (12 assertions, 전부 GREEN)
- 전체 회귀: 215 테스트 / 501 assertions GREEN (Incomplete 1건은 기존 무관)

이슈 #14 3차 구현. 1차 홈페이지(PR #148) → 2차 목록(PR #149) → 3차 상세(this PR) 순서.

## 결정사항

- slug 조회 시 `tenant_id` 스코프를 `WHERE` 절에 함께 적용 — 크로스 테넌트 접근 차단
- `nl2br(esc($post['content']))` 패턴으로 줄바꿈 보존 + XSS 방어 동시 처리
- 테넌트 격리 테스트에 양성(A사 포스트 → A사 URL 200) + 음성(B사 포스트 → A사 URL 404) 짝 단언 적용 (피드백 원칙 준수)

## 기술부채

- `show.php`에 `prose` 클래스 사용 중이나 `@tailwindcss/typography` 플러그인 미설치라 현재 시각적으로 무효 — 별도 이슈로 분리 가능
- 작성일 출력이 `<p>` 태그 — `<time datetime="...">` 시맨틱 태그로 개선 여지

## 남은 작업 (이슈 #14)

- 댓글 표시 UI
- 카테고리별/태그별 목록 페이지
- 검색 결과 페이지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 테넌트별 포스트 상세 보기 페이지 추가
  * 발행된 포스트만 조회 가능하며, 작성일 및 본문 내용 표시
  * 포스트 목록으로 돌아가기 링크 제공

* **Tests**
  * 포스트 조회 기능 검증 테스트 추가
  * 테넌트 격리 및 보안(XSS 방지) 검증 포함

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->