### PR TITLE
✨ feat: 테넌트 공개 포스트 댓글 표시 UI 추가 (#14)

### DIFF
--- a/app/Controllers/Tenant/PostsController.php
+++ b/app/Controllers/Tenant/PostsController.php
@@ -30,7 +30,7 @@ class PostsController extends BaseController
 
     public function show(string $tenantSlug, string $postSlug): string
     {
-        $page = (int) ($this->request->getGet('page') ?? 1);
+        $page = max(1, (int) ($this->request->getGet('page') ?? 1));
 
         $tenant = service('tenant')->getTenant();
         $postModel = model(PostModel::class);

--- a/app/Controllers/Tenant/PostsController.php
+++ b/app/Controllers/Tenant/PostsController.php
@@ -4,6 +4,7 @@ namespace App\Controllers\Tenant;
 
 use App\Controllers\BaseController;
 use App\Enums\PostState;
+use App\Models\CommentModel;
 use App\Models\PostModel;
 use CodeIgniter\Exceptions\PageNotFoundException;
 
@@ -29,10 +30,12 @@ class PostsController extends BaseController
 
     public function show(string $tenantSlug, string $postSlug): string
     {
-        $tenant = service('tenant')->getTenant();
-        $model = model(PostModel::class);
+        $page = (int) ($this->request->getGet('page') ?? 1);
 
-        $post = $model
+        $tenant = service('tenant')->getTenant();
+        $postModel = model(PostModel::class);
+
+        $post = $postModel
             ->where('tenant_id', $tenant->id)
             ->where('slug', $postSlug)
             ->where('state', PostState::PUBLISHED->value)
@@ -42,6 +45,10 @@ class PostsController extends BaseController
             throw PageNotFoundException::forPageNotFound();
         }
 
-        return view('tenant/posts/show', compact('post', 'tenant'));
+        $commentModel = model(CommentModel::class);
+        $comments = $commentModel->findThreaded($post->id, 10, $page);
+        $commentsPager = $commentModel->pager;
+
+        return view('tenant/posts/show', compact('post', 'tenant', 'comments', 'commentsPager'));
     }
 }

--- a/app/Views/tenant/posts/_comment.php
+++ b/app/Views/tenant/posts/_comment.php
@@ -1,0 +1,8 @@
+<div><?= nl2br(esc($comment->content)) ?></div>
+<div><?= esc(date('Y-m-d H:i', strtotime($comment->created_at))) ?></div>
+<?php foreach ($comment->replies as $reply) : ?>
+    <div class="ml-6 border-l">
+        <?= view('tenant/posts/_comment', ['comment' => $reply]) ?>
+    </div>
+<?php endforeach; ?>
+

--- a/app/Views/tenant/posts/show.php
+++ b/app/Views/tenant/posts/show.php
@@ -1,7 +1,7 @@
 <?= $this->extend('layouts/default') ?>
 
 <?= $this->section('title') ?>
-    <?= esc($post->title) ?> - <?= esc($tenant->name) ?>
+<?= esc($post->title) ?> - <?= esc($tenant->name) ?>
 <?= $this->endSection() ?>
 
 <?= $this->section('content') ?>
@@ -9,7 +9,9 @@
         <h1 class="text-3xl font-bold mb-2">
             <?= esc($post->title) ?>
         </h1>
-        <time class="text-sm text-nord-4 mb-6" datetime="<?= esc(date('Y-m-d', strtotime($post->created_at))) ?>">
+        <time class="text-sm text-nord-4 mb-6"
+                datetime="<?= esc(date('Y-m-d', strtotime($post->created_at))) ?>"
+        >
             <?= esc(date('Y-m-d', strtotime($post->created_at))) ?>
         </time>
 
@@ -17,7 +19,20 @@
             <?= nl2br(esc($post->content)) ?>
         </article>
 
-        <a class="btn btn-ghost btn-sm" href="<?= esc(site_url("{$tenant->subdomain}/posts"), 'attr') ?>">
+        <h2>댓글</h2>
+
+        <?php if (empty($comments)): ?>
+            <div>아직 댓글이 없습니다.</div>
+        <?php else: ?>
+            <?php foreach ($comments as $comment): ?>
+                <div><?= view('tenant/posts/_comment', compact('comment')) ?></div>
+            <?php endforeach; ?>
+            <div><?= $commentsPager->links() ?></div>
+        <?php endif; ?>
+
+        <a class="btn btn-ghost btn-sm"
+                href="<?= esc(site_url("{$tenant->subdomain}/posts"), 'attr') ?>"
+        >
             ← 포스트 목록으로
         </a>
     </div>

--- a/tests/feature/TenantPostsShowTest.php
+++ b/tests/feature/TenantPostsShowTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature;
 
 use App\Database\Seeds\TestSeeder;
+use App\Enums\CommentState;
 use App\Enums\PostState;
 use App\Models\CategoryModel;
+use App\Models\CommentModel;
 use App\Models\PostModel;
 use App\Models\TenantModel;
 use CodeIgniter\Exceptions\PageNotFoundException;
@@ -123,6 +125,108 @@ class TenantPostsShowTest extends CIUnitTestCase
         $response->assertDontSee('<script>alert(1)</script>');
         $response->assertSee('&lt;script&gt;');
         $response->assertSee('안전한본문');
+    }
+
+    /**
+     * @test
+     * 승인된 댓글이 보여야 함
+     */
+    public function test_displays_approved_comment(): void
+    {
+        $post = $this->createPost();
+        $path = $this->getPath(tenant: $this->tenant, post: $post);
+
+        fake(CommentModel::class, [
+            'post_id' => $post->id,
+            'content' => '승인된 댓글입니다',
+            'state'   => CommentState::APPROVED->value,
+        ]);
+
+        $response = $this->get(path: $path);
+
+        $response->assertStatus(200);
+        $response->assertSee('승인된 댓글입니다');
+    }
+
+    /**
+     * @test
+     * 미승인 댓글 숨김
+     */
+    public function test_hides_non_approved_comments(): void
+    {
+        $post = $this->createPost();
+        $path = $this->getPath(tenant: $this->tenant, post: $post);
+
+        fake(CommentModel::class, [
+            'post_id' => $post->id,
+            'content' => '승인된 댓글입니다',
+            'state'   => CommentState::APPROVED->value,
+        ]);
+
+        fake(CommentModel::class, [
+            'post_id' => $post->id,
+            'content' => '미승인된 댓글입니다',
+            'state'   => CommentState::PENDING->value,
+        ]);
+
+        $response = $this->get(path: $path);
+
+        $response->assertStatus(200);
+        $response->assertSee('승인된 댓글입니다');
+        $response->assertDontSee('미승인된 댓글입니다');
+    }
+
+    /**
+     * @test
+     * 댓글이 없을 때 안내문구 표시
+     */
+    public function test_shows_placeholder_when_no_comments(): void
+    {
+        $post = $this->createPost();
+        $path = $this->getPath(tenant: $this->tenant, post: $post);
+
+        $response = $this->get(path: $path);
+
+        $response->assertStatus(200);
+        $response->assertSee('아직 댓글이 없습니다.');
+    }
+
+    /**
+     * @test
+     * 댓글 재귀 렌더링 테스트
+     */
+    public function test_displays_nested_reply(): void
+    {
+        $post = $this->createPost();
+        $path = $this->getPath(tenant: $this->tenant, post: $post);
+
+        $rootComment = fake(CommentModel::class, [
+            'post_id' => $post->id,
+            'parent_id' => null,
+            'content' => '첫 번째 댓글입니다',
+            'state'   => CommentState::APPROVED->value,
+        ]);
+
+        $childComment = fake(CommentModel::class, [
+            'post_id' => $post->id,
+            'parent_id' => $rootComment->id,
+            'content' => '첫 번째 댓글의 대댓글입니다',
+            'state'   => CommentState::APPROVED->value,
+        ]);
+
+        fake(CommentModel::class, [
+            'post_id' => $post->id,
+            'parent_id' => $childComment->id,
+            'content' => '첫 번째 대댓글의 대대댓글입니다',
+            'state'   => CommentState::APPROVED->value,
+        ]);
+
+        $response = $this->get(path: $path);
+
+        $response->assertStatus(200);
+        $response->assertSee('첫 번째 댓글입니다');
+        $response->assertSee('첫 번째 댓글의 대댓글입니다');
+        $response->assertSee('첫 번째 대댓글의 대대댓글입니다');
     }
 
     // helper methods


### PR DESCRIPTION
## Summary

- `PostsController::show()`에서 `CommentModel::findThreaded()`로 승인된 댓글 트리 + pager를 조회해 뷰에 전달 (`?page` 쿼리 파라미터 처리 포함)
- `_comment.php` partial 뷰 신규 추가 — `replies`에 대해 자기 자신을 재귀 호출해 깊이 제한 없이 댓글 트리 렌더링
- `show.php` 댓글 섹션 추가 — 빈 목록 placeholder, 루트 댓글 순회, 페이지네이션 링크
- 표시 전용 구현 — 댓글 작성/수정/삭제 폼은 범위 밖 (후속 이슈 분리)

## 결정사항

- **표시 전용 범위**: 댓글 CRUD 폼은 이슈 #11(댓글 시스템) 또는 별도 이슈로 분리
- **결정 C — 작성자명 생략**: `findThreaded()`는 댓글 API와 공유되는 메서드라 users 조인 추가 시 영향 범위가 커서 후속으로 분리
- **페이지네이션**: `CommentModel::findThreaded()`의 pager를 그대로 활용

## 기술부채

- `_comment.php`·`show.php` 댓글 영역이 `<div>` 수준으로 DaisyUI 스타일 미정비
- 댓글 작성자명 미표시 (결정 C에 따른 의도적 후속 과제)

## 남은 작업 (이슈 #14)

- [ ] 카테고리별/태그별 포스트 목록 페이지
- [ ] 검색 결과 페이지

Closes #14 (부분 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시물 상세 페이지에 댓글 표시 기능 추가
  * 댓글에 대한 답글(중첩 대댓글) 지원
  * 댓글 페이지네이션 기능 구현
  * 승인된 댓글만 사용자에게 노출 (미승인 댓글 비표시)
  * 댓글이 없을 때 안내 메시지 표시

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->