### PR TITLE
✨ feat: 테넌트 카테고리별 포스트 목록 페이지 추가 (#14)

### DIFF
--- a/app/Controllers/Tenant/CategoriesController.php
+++ b/app/Controllers/Tenant/CategoriesController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Controllers\Tenant;
+
+use App\Controllers\BaseController;
+use App\Enums\PostState;
+use App\Models\CategoryModel;
+use App\Models\PostModel;
+use CodeIgniter\Exceptions\PageNotFoundException;
+
+class CategoriesController extends BaseController
+{
+    public function posts(string $tenantSlug, string $categorySlug): string
+    {
+        $tenant = service('tenant')->getTenant();
+        $postModel = model(PostModel::class);
+        $categoryModel = model(CategoryModel::class);
+
+        $category = $categoryModel
+            ->where('tenant_id', $tenant->id)
+            ->where('slug', $categorySlug)
+            ->first();
+
+        if ($category === null) {
+            throw PageNotFoundException::forPageNotFound();
+        }
+
+        $posts = $postModel
+            ->where('tenant_id', $tenant->id)
+            ->where('category_id', $category->id)
+            ->where('state', PostState::PUBLISHED->value)
+            ->orderBy('created_at', 'DESC')
+            ->paginate(10);
+
+        return view('tenant/categories/posts', [
+            'tenant'   => $tenant,
+            'category' => $category,
+            'posts'    => $posts,
+            'pager'    => $postModel->pager,
+        ]);
+    }
+}

--- a/app/Views/tenant/categories/posts.php
+++ b/app/Views/tenant/categories/posts.php
@@ -1,0 +1,43 @@
+<?= $this->extend('layouts/default') ?>
+
+<?= $this->section('title') ?>
+카테고리 - <?= esc($category->name) ?>
+<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+<div class="container mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold mb-8 text-nord-8">
+        <?= esc($category->name) ?>
+    </h1>
+
+    <?php if (empty($posts)): ?>
+        <div class="alert alert-info">아직 발행된 포스트가 없습니다.</div>
+    <?php else: ?>
+        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            <?php foreach ($posts as $post): ?>
+                    <article class="card bg-base-100 shadow-nord">
+                    <div class="card-body">
+                        <h2 class="card-title text-nord-7">
+                            <?= esc($post->title) ?>
+                        </h2>
+                        <p class="text-sm text-nord-4">
+                            <?= esc(date('Y-m-d', strtotime($post->created_at))) ?>
+                        </p>
+                        <p class="line-clamp-3">
+                            <?= esc(mb_substr(strip_tags($post->content), 0, 120)) ?>
+                        </p>
+                        <div class="card-actions justify-end">
+                            <a href="<?= esc(site_url("{$tenant->subdomain}/posts/{$post->slug}"), 'attr') ?>"
+                                class="btn btn-sm btn-primary">읽기</a>
+                        </div>
+                    </div>
+                    </article>
+            <?php endforeach; ?>
+        </div>
+
+        <div class="mt-10 flex justify-center">
+            <?= $pager->links('default', 'default_full') ?>
+        </div>
+    <?php endif; ?>
+</div>
+<?= $this->endSection() ?>

--- a/tests/feature/TenantCategoryPostsTest.php
+++ b/tests/feature/TenantCategoryPostsTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Database\Seeds\TestSeeder;
+use App\Enums\PostState;
+use App\Models\CategoryModel;
+use App\Models\PostModel;
+use App\Models\TenantModel;
+use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\FeatureTestTrait;
+
+class TenantCategoryPostsTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+    use FeatureTestTrait;
+
+    protected $refresh = true;
+    protected $namespace = null;
+    protected $seed = TestSeeder::class;
+    protected $tenant;
+    protected $category;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tenant = fake(TenantModel::class, ['subdomain' => 'acme', 'name' => 'Acme']);
+        $this->category = $this->createCategory('news');
+
+        service('tenant')->setTenant($this->tenant);
+    }
+
+    /**
+     * @test
+     * 카테고리 + published 포스트 표시
+     */
+    public function test_shows_category_posts(): void
+    {
+        // Given:
+        $this->createPost();
+
+        // When:
+        $response = $this->get($this->getApiUrl());
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('News');
+        $response->assertSee('Test Post Title');
+    }
+
+    /**
+     * @test
+     * 미존재 카테고리 slug → 404
+     */
+    public function test_returns_404_for_missing_category(): void
+    {
+        // Given: setUp이 이미 'news' 카테고리 만들어둠
+
+        // When:
+        $this->expectException(PageNotFoundException::class);
+
+        $this->get($this->getApiUrl('unknown'));
+    }
+
+    /**
+     * @test
+     * 다른 테넌트의 카테고리 slug → 404
+     */
+    public function test_isolates_categories_by_tenant(): void
+    {
+        // Given:
+        $otherTenant = fake(TenantModel::class, ['subdomain' => 'bravo', 'name' => 'Bravo']);
+        $otherCategory = $this->createCategory('news', $otherTenant->id);
+        fake(PostModel::class, [
+            'tenant_id'   => $otherTenant->id,
+            'category_id' => $otherCategory->id,
+            'title'       => 'Bravo 포스트',
+            'state'       => PostState::PUBLISHED->value,
+            'content'     => '다른 포스트 내용입니다.'
+        ]);
+
+        $this->createPost('Acme 포스트');
+
+        // When:
+        $response = $this->get($this->getApiUrl());
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('Acme 포스트');
+        $response->assertDontSee('Bravo 포스트');
+    }
+
+    /**
+     * @test
+     * draft 포스트 미표시
+     */
+    public function test_lists_only_published_post(): void
+    {
+        // Given:
+        $this->createPost('Draft 포스트', $this->category->id, PostState::DRAFT->value);
+        $this->createPost('Published 포스트', $this->category->id, PostState::PUBLISHED->value);
+
+        // When:
+        $response = $this->get($this->getApiUrl());
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('Published 포스트');
+        $response->assertDontSee('Draft 포스트');
+    }
+
+    /**
+     * @test
+     * 빈 카테고리 placeholder 표시
+     */
+    public function test_lists_placeholder(): void
+    {
+        // Given: 포스트 생성안함.
+
+        // When:
+        $response = $this->get($this->getApiUrl());
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('아직 발행된 포스트가 없습니다.');
+    }
+
+    /**
+     * @test
+     * 같은 tenant 내 category 격리 테스트
+     */
+    public function test_isolates_same_tenant(): void
+    {
+        // Given:
+        $this->createPost('News 포스트');
+
+        $otherCategory = $this->createCategory('sport');
+        $this->createPost('Sports 포스트', $otherCategory->id);
+
+        // When:
+        $response = $this->get($this->getApiUrl());
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('News 포스트');
+        $response->assertDontSee('Sports 포스트');
+    }
+
+    // helper methods
+    private function createPost(string $title = 'Test Post Title', ?int $categoryId = null, ?string $state = null): object
+    {
+        return fake(PostModel::class, [
+            'tenant_id'   => $this->tenant->id,
+            'category_id' => $categoryId ?? $this->category->id,
+            'title'       => $title,
+            'state'       => $state ?? PostState::PUBLISHED->value,
+            'content'     => '이것은 본문 내용입니다.'
+        ]);
+    }
+
+    private function createCategory(string $slug, ?int $tenantId = null): object
+    {
+        return fake(CategoryModel::class, [
+            'tenant_id' => $tenantId ?? $this->tenant->id,
+            'name'      => ucfirst($slug),
+            'slug'      => $slug,
+        ]);
+    }
+
+    private function getApiUrl($categorySlug = null): string
+    {
+        return "/{$this->tenant->subdomain}/categories/" . ($categorySlug ?? $this->category->slug);
+    }
+}


### PR DESCRIPTION
## Summary

이슈 #14 (5차) - 테넌트 공개 페이지에서 카테고리별 포스트 목록을 조회할 수 있는 페이지를 추가합니다.

- `/{tenant}/categories/{slug}` 라우트에서 카테고리 slug 기반으로 해당 테넌트의 포스트 목록 표시
- 카테고리가 해당 테넌트에 속하지 않으면 404 반환
- 공개(published) 포스트만 표시

## 결정사항

- 컨트롤러는 `app/Controllers/Tenant/CategoriesController.php`로 분리 — Tenant 네임스페이스 일관성 유지
- 카테고리 조회 시 `tenant_id` 스코프 적용 → cross-tenant 접근 차단 (이슈 #135 패턴 재활용)
- 뷰는 기존 포스트 목록 뷰(`tenant/posts/index.php`)와 동일한 카드 레이아웃 사용

## 기술부채

- 없음

## 남은 작업 (이슈 #14)

- 포스트 상세 페이지 내 카테고리 링크 연결 확인
- 태그별 포스트 목록 페이지 (별도 이슈로 분리 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 각 카테고리별 게시글 목록을 확인할 수 있습니다.
  * 발행된 게시글만 최신순으로 정렬되며, 10개 단위로 페이지네이션됩니다.
  * 게시글이 없는 경우 안내 메시지가 표시됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->