### PR TITLE
✨ feat: 테넌트 태그별 포스트 목록 페이지 추가 (#14) (#154)

### DIFF
--- a/app/Controllers/Tenant/TagsController.php
+++ b/app/Controllers/Tenant/TagsController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Controllers\Tenant;
+
+use App\Controllers\BaseController;
+use App\Enums\PostState;
+use App\Models\PostModel;
+use App\Models\TagModel;
+use CodeIgniter\Exceptions\PageNotFoundException;
+
+class TagsController extends BaseController
+{
+    public function posts(string $tenantSlug, string $tagSlug): string
+    {
+        $tenant = service('tenant')->getTenant();
+
+        $postModel = model(PostModel::class);
+
+        $tag = model(TagModel::class)
+            ->where('tenant_id', $tenant->id)
+            ->where('slug', $tagSlug)
+            ->first();
+
+        if ($tag === null) {
+            throw PageNotFoundException::forPageNotFound();
+        }
+
+        $posts = $postModel
+            ->select('posts.*')
+            ->join('post_tags', 'post_tags.post_id = posts.id')
+            ->where('post_tags.tag_id', $tag->id)
+            ->where('posts.tenant_id', $tenant->id)
+            ->where('posts.state', PostState::PUBLISHED->value)
+            ->orderBy('posts.created_at', 'DESC')
+            ->paginate(10);
+
+        return view('tenant/tags/posts', [
+            'tenant' => $tenant,
+            'tag'    => $tag,
+            'posts'  => $posts,
+            'pager'  => $postModel->pager
+        ]);
+    }
+}

--- a/app/Database/Migrations/2026-03-06-085800_CreateTagsTable.php
+++ b/app/Database/Migrations/2026-03-06-085800_CreateTagsTable.php
@@ -12,6 +12,7 @@ class CreateTagsTable extends Migration
             'id'         => ['type' => 'int', 'unsigned' => true, 'auto_increment' => true],
             'tenant_id'  => ['type' => 'int', 'unsigned' => true, 'null' => false],
             'name'       => ['type' => 'varchar', 'constraint' => 255, 'null' => false],
+            'slug'       => ['type' => 'varchar', 'constraint' => 255, 'null' => false],
             'created_at' => ['type' => 'datetime', 'null' => true],
             'updated_at' => ['type' => 'datetime', 'null' => true],
         ]);
@@ -19,6 +20,7 @@ class CreateTagsTable extends Migration
         $this->forge->addPrimaryKey('id');
         $this->forge->addForeignKey('tenant_id', 'tenants', 'id', 'NO ACTION', 'CASCADE');
         $this->forge->addUniqueKey(['tenant_id', 'name']);
+        $this->forge->addUniqueKey(['tenant_id', 'slug']);
         $this->forge->createTable('tags');
     }
 

--- a/app/Models/TagModel.php
+++ b/app/Models/TagModel.php
@@ -2,19 +2,22 @@
 
 namespace App\Models;
 
-use App\Entities\TagEntity;
-use CodeIgniter\Model;
 use Faker\Generator;
+use CodeIgniter\Model;
+use App\Entities\TagEntity;
+use App\Traits\SlugGeneratorTrait;
 
 class TagModel extends Model
 {
+    use SlugGeneratorTrait;
+
     protected $table = 'tags';
     protected $primaryKey = 'id';
     protected $useAutoIncrement = true;
     protected $returnType = TagEntity::class;
     protected $useSoftDeletes = false;
     protected $protectFields = true;
-    protected $allowedFields = ['tenant_id', 'name'];
+    protected $allowedFields = ['tenant_id', 'name', 'slug'];
 
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;
@@ -34,6 +37,10 @@ class TagModel extends Model
     protected $skipValidation = false;
     protected $cleanValidationRules = true;
 
+    protected $slugSource = 'name';
+    protected $beforeInsert = ['generateSlug'];
+    protected $beforeUpdate = ['generateSlug'];
+
     public function findByPost(int $postId, int $tenantId): array
     {
         return $this->select('tags.*')
@@ -45,9 +52,12 @@ class TagModel extends Model
 
     public function fake(Generator &$faker): array
     {
+        $slug = "{$faker->unique()->word}-{$faker->randomNumber(4)}";
+
         return [
             'tenant_id' => service('tenant')->getId() ?? 1,
-            'name'      => "{$faker->unique()->word}-{$faker->randomNumber(4)}",
+            'name'      => ucfirst($slug),
+            'slug'      => $slug,
         ];
     }
 }

--- a/app/Transformers/TagTransformer.php
+++ b/app/Transformers/TagTransformer.php
@@ -13,6 +13,7 @@ class TagTransformer extends BaseTransformer
         return [
             'id'         => $resource['id'],
             'name'       => $resource['name'],
+            'slug'       => $resource['slug'],
             'created_at' => $resource['created_at'],
             'updated_at' => $resource['updated_at'],
         ];
@@ -20,6 +21,6 @@ class TagTransformer extends BaseTransformer
 
     protected function getAllowedFields(): ?array
     {
-        return ['id', 'name', 'created_at', 'updated_at'];
+        return ['id', 'name', 'slug', 'created_at', 'updated_at'];
     }
 }

--- a/app/Views/tenant/tags/posts.php
+++ b/app/Views/tenant/tags/posts.php
@@ -1,0 +1,44 @@
+<?= $this->extend('layouts/default') ?>
+
+<?= $this->section('title') ?>
+태그 - <?= esc($tag->name) ?>
+<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+<div class="container mx-auto px-4 py-10">
+    <h1 class="text-3xl font-bold mb-8 text-nord-8">
+    #<?= esc($tag->name) ?> 포스트
+    </h1>
+
+    <?php if (empty($posts)): ?>
+        <div class="alert alert-info">아직 발행된 포스트가 없습니다.</div>
+    <?php else: ?>
+        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            <?php foreach ($posts as $post): ?>
+                <article class="card bg-base-100 shadow-nord">
+                    <div class="card-body">
+                        <h2 class="card-title text-nord-7">
+                            <?= esc($post->title) ?>
+                        </h2>
+                        <p class="text-sm text-nord-4">
+                            <?= esc(date('Y-m-d', strtotime($post->created_at))) ?>
+                        </p>
+                        <p class="line-clamp-3">
+                            <?= esc(mb_substr(strip_tags($post->content), 0, 120)) ?>
+                        </p>
+                        <div class="card-actions justify-end">
+                        <a href="<?= esc(site_url("{$tenant->subdomain}/posts/{$post->slug}"), 'attr') ?>"
+                                class="btn btn-sm btn-primary">읽기</a>
+                        </div>
+                    </div>
+                </article>
+            <?php endforeach; ?>
+        </div>
+
+        <div class="mt-10 flex justify-center">
+            <?= $pager->links('default', 'default_full') ?>
+        </div>
+    <?php endif; ?>
+</div>
+<?= $this->endSection() ?>
+

--- a/tests/feature/TenantPostsShowTest.php
+++ b/tests/feature/TenantPostsShowTest.php
@@ -228,8 +228,7 @@ class TenantPostsShowTest extends CIUnitTestCase
         $response->assertSee('첫 번째 댓글의 대댓글입니다');
         $response->assertSee('첫 번째 대댓글의 대대댓글입니다');
     }
-
-    // helper methods
+// helper methods
     private function createPost(string $state = PostState::PUBLISHED->value): object
     {
         return fake(PostModel::class, [
@@ -240,6 +239,7 @@ class TenantPostsShowTest extends CIUnitTestCase
             'content'     => '이것은 본문 내용입니다.'
         ]);
     }
+
 
     private function getPath(object $tenant, object $post): string
     {

--- a/tests/feature/TenantTagPostsTest.php
+++ b/tests/feature/TenantTagPostsTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Database\Seeds\TestSeeder;
+use App\Enums\PostState;
+use App\Models\CategoryModel;
+use App\Models\PostModel;
+use App\Models\TagModel;
+use App\Models\TenantModel;
+use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\FeatureTestTrait;
+
+class TenantTagPostsTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+    use FeatureTestTrait;
+
+    protected $refresh = true;
+    protected $namespace = null;
+    protected $seed = TestSeeder::class;
+    protected $tenant;
+    protected $category;
+    protected $tag;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tenant = fake(TenantModel::class, ['subdomain' => 'acme', 'name' => 'Acme']);
+        $this->category = $this->createCategory();
+        $this->tag = fake(TagModel::class, [
+            'tenant_id' => $this->tenant->id,
+            'name'      => 'Php',
+            'slug'      => 'php'
+        ]);
+    }
+
+    /**
+     * @test
+     * 태그 + 공개 포스트 표시
+     */
+    public function test_shows_tag_posts(): void
+    {
+        // Given:
+        $this->createPost(tagId: $this->tag->id);
+
+        // When:
+        $response = $this->get($this->getApiUrl());
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('Php');
+        $response->assertSee('Test post title');
+    }
+
+    /**
+     * @test
+     * 미존재 태그 slug → 404
+     */
+    public function test_returns_404_for_missing_tag(): void
+    {
+        // Given: setUp에서 이미 Tag 생성함.
+
+        // When:
+        $this->expectException(PageNotFoundException::class);
+
+        $this->get($this->getApiUrl('nonexistent-tag-slug'));
+    }
+
+    /**
+     * @test
+     * 테넌트 격리
+     */
+    public function test_isolates_tag_by_tenant(): void
+    {
+        // Given:
+        $otherTenant = fake(TenantModel::class, ['subdomain' => 'charlie', 'name' => 'Charlie']);
+
+        $otherCategory = $this->createCategory($otherTenant->id);
+
+        $otherTag = fake(TagModel::class, [
+            'tenant_id' => $otherTenant->id,
+            'slug'      => 'php',
+            'name'      => 'PHP',
+        ]);
+
+        $this->createPost(
+            title: 'charlie post title',
+            categoryId: $otherCategory->id,
+            tagId: $otherTag->id,
+            tenantId: $otherTenant->id
+        );
+
+        $this->createPost('acme post title', tagId: $this->tag->id);
+
+        // When:
+        $response = $this->get($this->getApiUrl());
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertDontSee('charlie post title');
+        $response->assertSee('acme post title');
+
+    }
+
+    /**
+     * @test
+     * 같은 테넌트 내 다른 태그 격리
+     */
+    public function test_same_tenant_different_tag_isolation(): void
+    {
+        // Given:
+        $jsTag = $this->createTag('javascript');
+
+        $this->createPost('php post', tagId: $this->tag->id);
+        $this->createPost('javascript post', tagId: $jsTag->id);
+
+        // When:
+        $response = $this->get($this->getApiUrl('php'));
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('php post');
+        $response->assertDontSee('javascript post');
+    }
+
+    /**
+     * @test
+     * 미공개 포스트는 리스트에서 제외
+     */
+    public function test_lists_only_published_post(): void
+    {
+        // Given:
+        $this->createPost('php post', tagId: $this->tag->id);
+        $this->createPost('python post', state: PostState::DRAFT->value, tagId: $this->tag->id);
+
+        // When:
+        $response = $this->get($this->getApiUrl());
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('php post');
+        $response->assertDontSee('python post');
+    }
+
+    /**
+     * @test
+     * 태그 이름으로 생성된 포스트가 없는 경우 placeholder를 표시
+     */
+    public function test_lists_placeholder(): void
+    {
+        // Given
+        $this->createTag('javascript');
+
+        // When:
+        $response = $this->get($this->getApiUrl('javascript'));
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('아직 발행된 포스트가 없습니다.');
+    }
+
+    /**
+     * @test
+     * 다중 태그를 가진 포스트를 생성하고, 해당 태그로 검색했을 때 포스트가 표시되는지 확인
+     */
+    public function test_post_with_multiple_tags(): void
+    {
+        // Given:
+        $jsTag = $this->createTag('javascript');
+        $post = $this->createPost(title: 'Multi-tag post', tagId: $this->tag->id);
+
+        model(PostModel::class)->syncTags($post->id, [$this->tag->id, $jsTag->id], $this->tenant->id);
+
+        // When:
+        $response = $this->get($this->getApiUrl('php'));
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('Multi-tag post');
+
+        // When:
+        $response = $this->get($this->getApiUrl('javascript'));
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('Multi-tag post');
+    }
+
+    // helper method
+    private function createPost(string  $title = 'Test post title',
+                                ?int    $categoryId = null,
+                                ?string $state = null,
+                                ?int    $tagId = null,
+                                ?int    $tenantId = null): object
+    {
+        $post = fake(PostModel::class, [
+            'tenant_id'   => $tenantId ?? $this->tenant->id,
+            'category_id' => $categoryId ?? $this->category->id,
+            'title'       => $title,
+            'state'       => $state ?? PostState::PUBLISHED->value,
+        ]);
+
+        if ($tagId !== null) {
+            model(PostModel::class)->syncTags($post->id, [$tagId], $tenantId ?? $this->tenant->id);
+        }
+
+        return $post;
+    }
+
+    private function getApiUrl($tagSlug = null): string
+    {
+        return "/{$this->tenant->subdomain}/tags/" . ($tagSlug ?? $this->tag->slug);
+    }
+
+    private function createCategory($tenantId = null): object
+    {
+        return fake(CategoryModel::class, [
+            'tenant_id' => $tenantId ?? $this->tenant->id,
+            'name'      => 'Test',
+            'slug'      => 'test'
+        ]);
+    }
+
+    private function createTag($tagSlug): object
+    {
+        return fake(TagModel::class, [
+            'tenant_id' => $this->tenant->id,
+            'slug'      => $tagSlug,
+            'name'      => ucfirst($tagSlug)
+        ]);
+    }
+}

--- a/tests/unit/TransformerTest.php
+++ b/tests/unit/TransformerTest.php
@@ -158,6 +158,7 @@ class TransformerTest extends CIUnitTestCase
         $resource = [
             'id'         => 1,
             'name'       => 'PHP',
+            'slug'       => 'php',
             'created_at' => null,
             'updated_at' => null,
         ];
@@ -165,8 +166,8 @@ class TransformerTest extends CIUnitTestCase
         $result = (new TagTransformer())->transform($resource);
 
         $this->assertSame(1, $result['id']);
-        $this->assertSame('PHP', $result['name']);
-        $this->assertArrayNotHasKey('slug', $result);
+        $this->assertSame('php', $result['slug']);
+        $this->assertArrayHasKey('slug', $result);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

이슈 #14 (프론트엔드 공개 페이지) 시리즈 6번째이자 마지막 작업.
PR #153 (카테고리 목록)에 이어 **태그별 포스트 목록** 페이지 구현.

**시리즈**: (1차) 홈 → (2차) 포스트 목록 → (3차) 상세 → (4차) 댓글 UI → (5차) 카테고리 목록 → **(6차) 태그 목록 (이번 PR)**

라우트 `/{tenant}/tags/{slug}`는 이미 `Routes.php:121`에 정의되어 있었으며 이번에 컨트롤러/뷰/테스트를 채움.

### 회귀 대응: TagModel 슬러그 인프라 추가

기존 `TagModel`에 `slug` 컬럼이 없었기 때문에, 컨트롤러 동작을 위해 다음을 함께 추가:

- `CreateTagsTable` 마이그레이션 직접 수정 — `slug NOT NULL` 컬럼 + `(tenant_id, slug)` 복합 유니크 키 (배포 전이므로 신규 파일 대신 기존 수정)
- `TagModel`에 `SlugGeneratorTrait` 적용 — `CategoryModel`과 완전 동일 패턴
- `TagTransformer`에 `slug` 필드 추가 — `CategoryTransformer` 일관성
- `TransformerTest` tag_transformer 케이스 slug 단언 업데이트

슬러그 인프라 추가로 기존 `TagsApiTest`가 8건 깨짐 → SlugGeneratorTrait 적용 → slug validation 충돌 발견 → 수정. 최종 회귀 0건.

---

## 결정사항

1. **`PostModel::findByTag()` 미수정** — 기존 메서드는 paginate 미지원이지만 변경 영향 검토 부담 회피. 컨트롤러에서 직접 JOIN 빌더 작성 (카테고리 컨트롤러와 동일 컨벤션). 이슈 #109(API 페이지네이션)에서 통합 정리 예정.
2. **테넌트 격리 시나리오: 옵션 X (같은 slug 중복 생성 대신 별도 테넌트+별도 태그)** — PR #153 카테고리 격리와 일관
3. **many-to-many 한 포스트 여러 태그 케이스 추가** — `syncTags` reset 동작 + 두 태그 페이지 각각 노출 검증
4. **``에 slug 미추가** — `beforeInsert` 콜백이 validate 후 실행되므로 `required` 위반 회피 (CategoryModel과 일치)

---

## 기술 부채

- **이슈 #109**: `PostModel::findByTag()`를 paginate 지원하도록 리팩토링 + API 레이어 일관성 정리 (카테고리 `findByCategory()`도 동일)

---

## 남은 작업 (#14 이슈 기준)

이슈 #14 공개 페이지 시리즈 **6차 완료** — 이슈 종료 상태 유지 (이미 Closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 태그별 포스트 목록 조회 기능이 추가되었습니다. 사용자는 특정 태그를 클릭하여 해당 태그로 분류된 발행된 포스트를 페이지네이션과 함께 볼 수 있습니다.
  * 태그 정보에 슬러그 필드가 추가되어 태그 조회 성능이 개선되었습니다.

* **Tests**
  * 태그별 포스트 목록 조회 기능에 대한 포괄적인 테스트 케이스가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->