### PR TITLE
✨ feat: 미디어 API CRUD 추가 (index/show/delete) (#12)

### DIFF
--- a/app/Controllers/Api/V1/MediaController.php
+++ b/app/Controllers/Api/V1/MediaController.php
@@ -129,8 +129,8 @@ class MediaController extends BaseApiController
             return $this->failForbidden();
         }
 
-        $this->storage->delete($media->path);
         $this->model->delete($media->id);
+        $this->storage->delete($media->path);
 
         return $this->respondNoContent();
     }

--- a/app/Controllers/Api/V1/MediaController.php
+++ b/app/Controllers/Api/V1/MediaController.php
@@ -6,6 +6,7 @@ use App\Enums\MediaType;
 use App\Libraries\MediaStorage\MediaStorageInterface;
 use App\Models\MediaModel;
 use App\Transformers\MediaTransformer;
+use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Router\Attributes\Filter;
 use Config\Services;
 use Exception;
@@ -20,6 +21,36 @@ class MediaController extends BaseApiController
     {
         $this->transformer = new MediaTransformer();
         $this->storage = Services::mediaStorage();
+    }
+
+    #[Filter(by: 'tokens')]
+    public function index(): ResponseInterface
+    {
+        $tenantId = auth()->user()->tenant_id;
+        $page = $this->request->getGet('page');
+
+        $media = $this->model
+            ->where('tenant_id', $tenantId)
+            ->orderBy('created_at', 'DESC')
+            ->paginate(20, 'default', $page);
+
+        return $this->responseWith($this->transformer->transformMany($media), $this->model->pager);
+    }
+
+    #[Filter(by: 'tokens')]
+    public function show($id = null): ResponseInterface
+    {
+        $tenantId = auth()->user()->tenant_id;
+
+        $media = $this->model
+            ->where('tenant_id', $tenantId)
+            ->find($id);
+
+        if ($media === null) {
+            return $this->failNotFound('Media not found');
+        }
+
+        return $this->responseWithItem($this->transformer->transform($media));
     }
 
     #[Filter(by: 'tokens')]
@@ -75,5 +106,32 @@ class MediaController extends BaseApiController
         }
 
         return $this->responseWithItem($this->transformer->transform($createdMedia), 201);
+    }
+
+    #[Filter(by: 'tokens')]
+    public function delete($id = null): ResponseInterface
+    {
+        $tenantId = auth()->user()->tenant_id;
+
+        $media = $this->model
+            ->where('tenant_id', $tenantId)
+            ->find($id);
+
+        if ($media === null) {
+            return $this->failNotFound('Media not found');
+        }
+
+        $user = auth()->user();
+        $isAdmin = $user->inGroup('admin');
+        $isOwner = $media->uploader_id === $user->id;
+
+        if (!$isAdmin && !$isOwner) {
+            return $this->failForbidden();
+        }
+
+        $this->storage->delete($media->path);
+        $this->model->delete($media->id);
+
+        return $this->respondNoContent();
     }
 }

--- a/tests/_support/Libraries/MediaStorage/FakeMediaStorage.php
+++ b/tests/_support/Libraries/MediaStorage/FakeMediaStorage.php
@@ -28,6 +28,11 @@ class FakeMediaStorage implements MediaStorageInterface
         }
     }
 
+    public function addExisting(string $path): void
+    {
+        $this->stored[] = $path;
+    }
+
     public function hasFile(string $path): bool
     {
         return in_array($path, $this->stored, true);

--- a/tests/api/MediaApiTest.php
+++ b/tests/api/MediaApiTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Api;
 
 use App\Database\Seeds\TestSeeder;
+use App\Enums\MediaType;
+use App\Models\MediaModel;
 use App\Models\TenantModel;
+use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\Fabricator;
@@ -132,6 +135,239 @@ class MediaApiTest extends CIUnitTestCase
         $this->assertCount(0, $this->fakeStorage->getStoredFiles());
     }
 
+    /**
+     * @test 인증 토큰 없이 미디어 목록을 요청하면 401 반환
+     */
+    public function test_index_requires_authentication(): void
+    {
+        $response = $this->get('/api/v1/media');
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * @test 본인 테넌트 미디어만 조회되고 타 테넌트 미디어는 노출되지 않음
+     */
+    public function test_index_returns_only_own_tenant_media(): void
+    {
+        $otherTenant = (new Fabricator(TenantModel::class))->create();
+
+        $myMediaId    = $this->createMediaFixture($this->tenant->id, ['original_name' => 'my-tenant.jpg']);
+        $otherMediaId = $this->createMediaFixture($otherTenant->id, ['original_name' => 'other-tenant.jpg']);
+
+        $response = $this->withHeaders($this->getAuthHeader())->get('/api/v1/media');
+
+        $response->assertStatus(200);
+
+        $json = json_decode($response->getJSON(), true);
+        $ids  = array_column($json['data']['items'], 'id');
+
+        $this->assertContains($myMediaId, $ids, '본인 테넌트 미디어가 목록에 포함되어야 함');
+        $this->assertNotContains($otherMediaId, $ids, '타 테넌트 미디어는 목록에 노출되지 않아야 함');
+    }
+
+    /**
+     * @test 페이지네이션 기본 perPage=20 동작 및 메타 응답
+     */
+    public function test_index_paginates_with_default_per_page_20(): void
+    {
+        for ($i = 0; $i < 25; $i++) {
+            $this->createMediaFixture($this->tenant->id);
+        }
+
+        $response = $this->withHeaders($this->getAuthHeader())->get('/api/v1/media');
+
+        $response->assertStatus(200);
+
+        $json = json_decode($response->getJSON(), true);
+
+        $this->assertCount(20, $json['data']['items']);
+        $this->assertSame(25, $json['data']['pagination']['total']);
+        $this->assertSame(20, $json['data']['pagination']['per_page']);
+        $this->assertSame(1, $json['data']['pagination']['current_page']);
+        $this->assertSame(2, $json['data']['pagination']['last_page']);
+
+        $response2 = $this->withHeaders($this->getAuthHeader())->get('/api/v1/media?page=2');
+        $json2     = json_decode($response2->getJSON(), true);
+
+        $this->assertCount(5, $json2['data']['items']);
+        $this->assertSame(2, $json2['data']['pagination']['current_page']);
+    }
+
+    /**
+     * @test 미디어가 없을 때 빈 items 배열과 pagination 메타 반환
+     */
+    public function test_index_returns_empty_items_when_no_media(): void
+    {
+        $response = $this->withHeaders($this->getAuthHeader())->get('/api/v1/media');
+
+        $response->assertStatus(200);
+
+        $json = json_decode($response->getJSON(), true);
+
+        $this->assertArrayHasKey('items', $json['data']);
+        $this->assertArrayHasKey('pagination', $json['data']);
+        $this->assertCount(0, $json['data']['items']);
+        $this->assertSame(0, $json['data']['pagination']['total']);
+    }
+
+    /**
+     * @test 본인 테넌트 미디어 상세 조회 시 200과 transformer 응답 반환
+     */
+    public function test_show_returns_own_tenant_media(): void
+    {
+        $mediaId = $this->createMediaFixture($this->tenant->id, [
+            'original_name' => 'detail.jpg',
+            'mime_type'     => 'image/jpeg',
+        ]);
+
+        $response = $this->withHeaders($this->getAuthHeader())->get('/api/v1/media/' . $mediaId);
+
+        $response->assertStatus(200);
+
+        $json = json_decode($response->getJSON(), true);
+
+        $this->assertSame($mediaId, $json['data']['id']);
+        $this->assertSame('detail.jpg', $json['data']['original_name']);
+        $this->assertSame('image/jpeg', $json['data']['mime_type']);
+    }
+
+    /**
+     * @test 타 테넌트 미디어 ID로 조회 시 404 반환 (테넌트 격리)
+     */
+    public function test_show_returns_404_for_other_tenant(): void
+    {
+        $otherTenant  = (new Fabricator(TenantModel::class))->create();
+        $otherMediaId = $this->createMediaFixture($otherTenant->id);
+
+        $response = $this->withHeaders($this->getAuthHeader())->get('/api/v1/media/' . $otherMediaId);
+
+        $response->assertStatus(404);
+    }
+
+    /**
+     * @test 존재하지 않는 미디어 ID 조회 시 404 반환
+     */
+    public function test_show_returns_404_for_nonexistent_id(): void
+    {
+        $response = $this->withHeaders($this->getAuthHeader())->get('/api/v1/media/999999');
+
+        $response->assertStatus(404);
+    }
+
+    /**
+     * @test 인증 토큰 없이 상세 조회 시 401 반환
+     */
+    public function test_show_requires_authentication(): void
+    {
+        $mediaId = $this->createMediaFixture($this->tenant->id);
+
+        $response = $this->get('/api/v1/media/' . $mediaId);
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * @test 인증 토큰 없이 삭제 시 401 반환
+     */
+    public function test_delete_requires_authentication(): void
+    {
+        $mediaId = $this->createMediaFixture($this->tenant->id);
+
+        $response = $this->delete('/api/v1/media/' . $mediaId);
+
+        $response->assertStatus(401);
+
+        $this->seeInDatabase('media', ['id' => $mediaId]);
+        $this->assertTrue($this->fakeStorage->hasFile(
+            model(MediaModel::class)->find($mediaId)->path
+        ));
+    }
+
+    /**
+     * @test 타 테넌트 미디어 삭제 시 404 반환 (격리 — 존재 여부 노출 차단)
+     */
+    public function test_delete_returns_404_for_other_tenant(): void
+    {
+        $otherTenant  = (new Fabricator(TenantModel::class))->create();
+        $otherMediaId = $this->createMediaFixture($otherTenant->id);
+        $otherPath    = model(MediaModel::class)->find($otherMediaId)->path;
+
+        $response = $this->withHeaders($this->getAuthHeader())
+            ->delete('/api/v1/media/' . $otherMediaId);
+
+        $response->assertStatus(404);
+
+        $this->seeInDatabase('media', ['id' => $otherMediaId]);
+        $this->assertTrue($this->fakeStorage->hasFile($otherPath));
+    }
+
+    /**
+     * @test 존재하지 않는 미디어 ID 삭제 시 404 반환
+     */
+    public function test_delete_returns_404_for_nonexistent_id(): void
+    {
+        $response = $this->withHeaders($this->getAuthHeader())
+            ->delete('/api/v1/media/999999');
+
+        $response->assertStatus(404);
+    }
+
+    /**
+     * @test 업로더 본인이 자신의 미디어 삭제 시 204 + DB row + Storage 파일 정리
+     */
+    public function test_delete_by_uploader_succeeds(): void
+    {
+        $uploader = $this->createTenantUser($this->tenant->id, 'uploader@example.com', ['user']);
+        $mediaId  = $this->createMediaFixture($this->tenant->id, ['uploader_id' => $uploader->id]);
+        $path     = model(MediaModel::class)->find($mediaId)->path;
+
+        $response = $this->withHeaders($this->getAuthHeaderForUser($uploader))
+            ->delete('/api/v1/media/' . $mediaId);
+
+        $response->assertStatus(204);
+
+        $this->dontSeeInDatabase('media', ['id' => $mediaId]);
+        $this->assertFalse($this->fakeStorage->hasFile($path), '업로더 본인 삭제 시 Storage 파일도 정리되어야 함');
+    }
+
+    /**
+     * @test 같은 테넌트의 admin이 타인 업로드 미디어 삭제 시 204 + 파일 정리
+     */
+    public function test_delete_by_admin_for_other_uploader_succeeds(): void
+    {
+        $uploader = $this->createTenantUser($this->tenant->id, 'uploader2@example.com', ['user']);
+        $mediaId  = $this->createMediaFixture($this->tenant->id, ['uploader_id' => $uploader->id]);
+        $path     = model(MediaModel::class)->find($mediaId)->path;
+
+        $response = $this->withHeaders($this->getAuthHeader())
+            ->delete('/api/v1/media/' . $mediaId);
+
+        $response->assertStatus(204);
+
+        $this->dontSeeInDatabase('media', ['id' => $mediaId]);
+        $this->assertFalse($this->fakeStorage->hasFile($path), 'admin 삭제 시 Storage 파일도 정리되어야 함');
+    }
+
+    /**
+     * @test 같은 테넌트의 다른 일반 사용자가 타인 업로드 미디어 삭제 시 403 + DB/Storage 유지
+     */
+    public function test_delete_by_other_regular_user_returns_403(): void
+    {
+        $uploader = $this->createTenantUser($this->tenant->id, 'uploader3@example.com', ['user']);
+        $intruder = $this->createTenantUser($this->tenant->id, 'intruder@example.com', ['user']);
+        $mediaId  = $this->createMediaFixture($this->tenant->id, ['uploader_id' => $uploader->id]);
+        $path     = model(MediaModel::class)->find($mediaId)->path;
+
+        $response = $this->withHeaders($this->getAuthHeaderForUser($intruder))
+            ->delete('/api/v1/media/' . $mediaId);
+
+        $response->assertStatus(403);
+
+        $this->seeInDatabase('media', ['id' => $mediaId]);
+        $this->assertTrue($this->fakeStorage->hasFile($path), '권한 없을 시 Storage 파일은 유지되어야 함');
+    }
+
     protected function tearDown(): void
     {
         foreach ($this->tempFiles as $tempFile) {
@@ -194,5 +430,57 @@ class MediaApiTest extends CIUnitTestCase
             'Authorization' => 'Bearer ' . $token,
             'X-Tenant-Slug' => $this->tenant->subdomain,
         ];
+    }
+
+    private function createTenantUser(int $tenantId, string $email, array $groups = ['user']): User
+    {
+        $user = new User([
+            'email'    => $email,
+            'username' => explode('@', $email)[0],
+            'password' => 'password123!',
+        ]);
+
+        $this->userModel->save($user);
+        $newId = $this->userModel->getInsertID();
+        $this->userModel->update($newId, ['tenant_id' => $tenantId]);
+
+        $created = $this->userModel->findById($newId);
+        foreach ($groups as $group) {
+            $created->addGroup($group);
+        }
+
+        return $created;
+    }
+
+    private function getAuthHeaderForUser(User $user): array
+    {
+        $token = $user->generateAccessToken('test')->raw_token;
+
+        return [
+            'Authorization' => 'Bearer ' . $token,
+            'X-Tenant-Slug' => $this->tenant->subdomain,
+        ];
+    }
+
+    private function createMediaFixture(int $tenantId, array $overrides = []): int
+    {
+        $uniq = uniqid('fixture_', true);
+
+        $data = array_merge([
+            'tenant_id'     => $tenantId,
+            'uploader_id'   => $this->admin->id,
+            'type'          => MediaType::Image->value,
+            'mime_type'     => 'image/jpeg',
+            'filename'      => $uniq . '.jpg',
+            'original_name' => 'fixture.jpg',
+            'file_size'     => 1024,
+            'path'          => $tenantId . '/' . $uniq . '.jpg',
+        ], $overrides);
+
+        $id = model(MediaModel::class)->insert($data, true);
+
+        $this->fakeStorage->addExisting($data['path']);
+
+        return $id;
     }
 }


### PR DESCRIPTION
## Summary

이슈 #12 (미디어 라이브러리) 후속 작업.
PR #152 (Storage 추상화 + 업로드 API)에 이어 **Media API의 RESTful CRUD** 마무리.

**시리즈**: (1차) Storage 추상화 + 업로드 → **(2차) index/show/delete (이번 PR)** → (예정) 필터링/썸네일/관리 UI

### 추가된 엔드포인트

| 메서드 | 경로 | 동작 |
|---|---|---|
| `GET` | `/api/v1/media` | 본인 테넌트 미디어 목록, `created_at DESC`, perPage=20 |
| `GET` | `/api/v1/media/{id}` | 본인 테넌트 단건 조회, 격리 → 404 |
| `DELETE` | `/api/v1/media/{id}` | 업로더 본인 또는 admin 그룹만 허용, DB row + Storage 파일 함께 정리 |

테스트: MediaApiTest **19/19 GREEN**, 55 assertions (upload 5 기존 + index 4 + show 4 + delete 6 신규).
전체 회귀: 251 tests / 602 assertions / 0 failures.

---

## 결정사항

1. **이번 PR 범위: 기본 CRUD만** — 필터링(type/q/uploader_id)은 별도 이슈로 분리. PR 크기/리뷰 부담 회피
2. **삭제 권한 정책: 업로더 본인 + admin 그룹** — `PostsController::delete`의 `isAuthorized()` 패턴과 일관
3. **perPage = 20** — PostModel과 일치, 일관성 우선
4. **페이지네이션 `?page` 명시 전달** — CI4 Pager 싱글톤이 같은 테스트 내 두 번째 호출에서 캐싱된 상태를 유지하는 약점 확인. `paginate(20, 'default', $page)` 3번째 인수에 명시 전달로 회피. PostsController도 동일 약점이 있으나 이번 스코프 외
5. **OpenAPI 명세 업데이트 X** — `docs/openapi.yaml` 파일 자체가 부재 → 이슈 #101 (명세 정리)에서 통합 처리
6. **테스트 픽스처 헬퍼 신규**:
   - `createMediaFixture()` — DB row + `FakeMediaStorage` 사전 등록 단일 회입점
   - `createTenantUser()`, `getAuthHeaderForUser()` — 권한 분기 케이스용 비-admin 사용자/토큰
   - `FakeMediaStorage::addExisting()` — 외부에서 stored 배열에 추가하는 한 줄 메서드

---

## 기술 부채

- **`MediaModel::deleteWithStorage()` 캡슐화 미적용** — DB row + 외부 Storage 두 시스템 조작이지만 Controller에서 직접 처리 중. `feedback_controller_model_pattern.md` 원칙상 도메인 메서드로 묶는 후보. 다음 단계(필터링/썸네일 등)에서 함께 정리 권장
- **삭제 순서**: 현재 Storage→DB. Storage 성공 후 DB delete 실패 시 고아 DB row 가능. 트랜잭션 또는 DB→Storage 순서 검토 필요
- **권한 헬퍼 통일**: `PostsController::isAuthorized()`와 동일한 본인/admin 분기 로직이 두 컨트롤러에 흩어짐. `BaseApiController`로 끌어올리는 리팩토링 후보
- **`PostsController` paginate 자동 인식 약점**: 같은 약점으로 다중 페이지 검증 시 실패. 별도 이슈로 정리 가능

---

## 남은 작업 (#12 이슈 기준)

- [ ] 필터링/검색 (type, uploader_id, q) — 별도 이슈
- [ ] 이미지 썸네일 생성 — 별도 이슈
- [ ] 미디어 라이브러리 관리 UI (`Tenant\Admin\MediaController`) — 별도 이슈

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 미디어 목록 조회 API 추가 (기본 페이지당 20개 항목 페이지네이션 지원)
* 미디어 상세 조회 API 추가
* 미디어 삭제 API 추가 (업로더 또는 관리자만 권한 보유)
* 모든 미디어 API 엔드포인트에 토큰 기반 인증 및 테넌트 데이터 격리 적용

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nambak/ci4-cms/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->