### PR TITLE
✨ feat: 대시보드 2차 - 최근 활동 + 인기 포스트 위젯 (#160)

### DIFF
--- a/app/Controllers/Tenant/Admin/DashboardController.php
+++ b/app/Controllers/Tenant/Admin/DashboardController.php
@@ -25,14 +25,27 @@ class DashboardController extends BaseAdminController
             ->where('posts.tenant_id', $tenant->id)
             ->countAllResults();
 
+        $popularPosts = model(PostModel::class)
+            ->popularByComments($tenant->id, 5);
+
+        $recentPosts = model(PostModel::class)
+            ->recent($tenant->id, 5);
+
+        $recentComments = model(CommentModel::class)
+            ->recent($tenant->id, 5);
+
         return $this->adminView(
             'tenant/admin/dashboard/index',
             [
-                'activeMenu'   => 'dashboard',
-                'pageTitle'    => 'Dashboard',
-                'postCount'    => $postCount,
-                'userCount'    => $userCount,
-                'commentCount' => $commentCount,
+                'activeMenu'     => 'dashboard',
+                'pageTitle'      => 'Dashboard',
+                'postCount'      => $postCount,
+                'userCount'      => $userCount,
+                'commentCount'   => $commentCount,
+                'popularPosts'   => $popularPosts,
+                'tenant'         => $tenant,
+                'recentPosts'    => $recentPosts,
+                'recentComments' => $recentComments
             ]
         );
     }

--- a/app/Models/CommentModel.php
+++ b/app/Models/CommentModel.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Entities\CommentEntity;
 use App\Enums\CommentState;
+use App\Enums\PostState;
 use CodeIgniter\Model;
 use CodeIgniter\Test\Fabricator;
 use Faker\Generator;
@@ -124,6 +125,8 @@ class CommentModel extends Model
         return $this->select(['comments.*', 'posts.title as post_title', 'posts.slug as post_slug'])
             ->join('posts', 'comments.post_id = posts.id')
             ->where('posts.tenant_id', $tenantId)
+            ->where('comments.state', CommentState::APPROVED->value)
+            ->where('posts.state', PostState::PUBLISHED->value)
             ->orderBy('comments.created_at', 'DESC')
             ->orderBy('comments.id', 'DESC')
             ->limit($limit)

--- a/app/Models/CommentModel.php
+++ b/app/Models/CommentModel.php
@@ -112,4 +112,21 @@ class CommentModel extends Model
 
         return $children;
     }
+
+    /**
+     * 최근 댓글
+     * @param int $tenantId
+     * @param int $limit
+     * @return array
+     */
+    public function recent(int $tenantId, int $limit): array
+    {
+        return $this->select(['comments.*', 'posts.title as post_title', 'posts.slug as post_slug'])
+            ->join('posts', 'comments.post_id = posts.id')
+            ->where('posts.tenant_id', $tenantId)
+            ->orderBy('comments.created_at', 'DESC')
+            ->orderBy('comments.id', 'DESC')
+            ->limit($limit)
+            ->findAll();
+    }
 }

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -2,12 +2,12 @@
 
 namespace App\Models;
 
-use Throwable;
-use Faker\Generator;
-use CodeIgniter\Model;
-use InvalidArgumentException;
 use App\Entities\PostEntity;
 use App\Traits\SlugGeneratorTrait;
+use CodeIgniter\Model;
+use Faker\Generator;
+use InvalidArgumentException;
+use Throwable;
 
 /**
  * @method PostEntity|null find($id = null)
@@ -214,6 +214,45 @@ class PostModel extends Model
             ->where('post_tags.tag_id', $tagId)
             ->where('posts.tenant_id', $tenantId)
             ->where('posts.state', 'published')
+            ->findAll();
+    }
+
+
+    /**
+     * 인기 포스트 순위(댓글수 기준)
+     *
+     * @param int $tenantId
+     * @param int $limit
+     * @return array
+     */
+    public function popularByComments(int $tenantId, int $limit): array
+    {
+        return $this->select('posts.*')
+            ->selectCount('comments.id', 'comment_count')
+            ->join('comments', 'comments.post_id = posts.id')
+            ->where('posts.tenant_id', $tenantId)
+            ->where('posts.state', 'published')
+            ->groupBy('posts.id')
+            ->orderBy('comment_count', 'DESC')
+            ->orderBy('posts.id', 'DESC')
+            ->limit($limit)
+            ->findAll();
+    }
+
+    /**
+     * 최근 포스트
+     *
+     * @param int $tenantId
+     * @param int $limit
+     * @return array
+     */
+    public function recent(int $tenantId, int $limit): array
+    {
+        return $this->select('posts.*')
+            ->where('posts.tenant_id', $tenantId)
+            ->where('posts.state', 'published')
+            ->orderBy('posts.id', 'DESC')
+            ->limit($limit)
             ->findAll();
     }
 }

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Entities\PostEntity;
+use App\Enums\CommentState;
 use App\Traits\SlugGeneratorTrait;
 use CodeIgniter\Model;
 use Faker\Generator;
@@ -232,6 +233,8 @@ class PostModel extends Model
             ->join('comments', 'comments.post_id = posts.id')
             ->where('posts.tenant_id', $tenantId)
             ->where('posts.state', 'published')
+            ->where('comments.state', CommentState::APPROVED->value)
+            ->where('comments.deleted_at', null)
             ->groupBy('posts.id')
             ->orderBy('comment_count', 'DESC')
             ->orderBy('posts.id', 'DESC')

--- a/app/Views/tenant/admin/dashboard/index.php
+++ b/app/Views/tenant/admin/dashboard/index.php
@@ -25,6 +25,50 @@
             <div class="stat-title text-nord-3">총 댓글 수</div>
             <div class="stat-value text-right" data-testid="stat-comments"><?= number_format($commentCount) ?></div>
         </div>
+        <div class="stat shadow bg-nord-6 rounded-md">
+            <div class="stat-title text-nord-3">인기 포스트</div>
+            <div class="stat-value" data-testid="widget-popular-posts">
+                <?php foreach ($popularPosts as $post) : ?>
+                    <div class="flex items-center justify-between">
+                        <a href="<?= esc(site_url("{$tenant->subdomain}/posts/{$post->slug}"), 'attr') ?>"
+                                class="text-nord-0 hover:text-nord-1"
+                        >
+                            <?= esc($post->title) ?>
+                        </a>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+        <div class="stat shadow bg-nord-6 rounded-md">
+            <div class="stat-title text-nord-3">최신 포스트</div>
+            <div class="stat-value" data-testid="widget-recent-posts">
+                <?php foreach ($recentPosts as $post): ?>
+                    <div class="flex items-center justify-between">
+                        <a href="<?= esc(site_url("{$tenant->subdomain}/posts/{$post->slug}"), 'attr') ?>"
+                                class="text-nord-0 hover:text-nord-1"
+                        >
+                            <?= esc($post->title) ?>
+                        </a>
+                        <div class="text-right text-nord-3"><?= esc($post->created_at->humanize()) ?></div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+        <div class="stat shadow bg-nord-6 rounded-md">
+            <div class="stat-title text-nord-3">최신 댓글</div>
+            <div class="stat-value" data-testid="widget-recent-comments">
+                <?php foreach ($recentComments as $comment): ?>
+                    <div class="flex items-center justify-between">
+                        <a href="<?= esc(site_url("{$tenant->subdomain}/posts/{$comment->post_slug}"), 'attr') ?>"
+                                class="text-nord-0 hover:text-nord-1"
+                        >
+                            <?= esc($comment->post_title) ?>
+                        </a>
+                        <div class="text-right text-nord-3"><?= esc($comment->created_at->humanize()) ?></div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
     </div>
 </div>
 <?= $this->endSection() ?>

--- a/app/Views/tenant/admin/dashboard/index.php
+++ b/app/Views/tenant/admin/dashboard/index.php
@@ -35,6 +35,7 @@
                         >
                             <?= esc($post->title) ?>
                         </a>
+                        <div class="text-right text-nord-3"><?= esc($post->comment_count) ?></div>
                     </div>
                 <?php endforeach; ?>
             </div>

--- a/tests/feature/TenantAdminDashboardTest.php
+++ b/tests/feature/TenantAdminDashboardTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\CommentState;
 use App\Enums\PostState;
 use App\Models\CategoryModel;
 use App\Models\CommentModel;
@@ -118,7 +119,7 @@ class TenantAdminDashboardTest extends CIUnitTestCase
 
         $post = $this->createPost($tenant, $category, $adminUser, $title);
 
-        $this->createComments($post[0]);
+        $this->createComments($post[0], CommentState::APPROVED->value);
 
         // When:
         $response = $this->get("{$tenant->subdomain}/admin");
@@ -141,9 +142,10 @@ class TenantAdminDashboardTest extends CIUnitTestCase
         $this->actingAs($adminUser);
 
         $popularPost = $this->createPost($tenant, $category, $adminUser, '인기글');
-        $quietPost = $this->createPost($tenant, $category, $adminUser, '조용한 글');
+        $this->createComments($popularPost[0], CommentState::APPROVED->value);
 
-        $this->createComments($popularPost[0], 3);
+        $this->createPost($tenant, $category, $adminUser, '조용한 글');
+
 
         // When:
         $response = $this->get("{$tenant->subdomain}/admin");
@@ -152,6 +154,82 @@ class TenantAdminDashboardTest extends CIUnitTestCase
         $response->assertStatus(200);
         $response->assertSee('인기글', 'div[data-testid=widget-popular-posts]');
         $response->assertDontSee('조용한 글', 'div[data-testid=widget-popular-posts]');
+    }
+
+    /**
+     * @test 최근 댓글 미승인 제외
+     */
+    public function test_dashboard_loads_recent_comment_without_pending(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('test');
+        $category = $this->createCategory($tenant);
+        $adminUser = $this->createUser($tenant);
+        $this->actingAs($adminUser);
+
+        $popularPost = $this->createPost($tenant, $category, $adminUser, '인기글');
+        $this->createComments($popularPost[0], CommentState::APPROVED->value);
+
+        $pendingPost = $this->createPost($tenant, $category, $adminUser, '미승인 댓글');
+        $this->createComments($pendingPost[0], CommentState::PENDING->value);
+
+        // When:
+        $response = $this->get("{$tenant->subdomain}/admin");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('인기글', 'div[data-testid=widget-recent-comments]');
+        $response->assertDontSee('미승인 댓글', 'div[data-testid=widget-recent-comments]');
+    }
+
+    /**
+     * @test draft 포스트 댓글 제외
+     */
+    public function test_dashboard_loads_recent_comment_without_draft_post_comments(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('test');
+        $adminUser = $this->createUser($tenant);
+        $category = $this->createCategory($tenant);
+        $this->actingAs($adminUser);
+
+        $publishedPost = $this->createPost($tenant, $category, $adminUser, '최근글');
+        $draftPost = $this->createPost($tenant, $category, $adminUser, '임시저장글', 1, PostState::DRAFT->value);
+
+        $this->createComments($publishedPost[0], CommentState::APPROVED->value);
+        $this->createComments($draftPost[0], CommentState::APPROVED->value);
+
+        // When:
+        $response = $this->get("{$tenant->subdomain}/admin");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('최근글', 'div[data-testid=widget-recent-comments]');
+        $response->assertDontSee('임시저장글', 'div[data-testid=widget-recent-comments]');
+    }
+
+    /**
+     * @test 소프트 삭제 댓글은 인기 포스트 댓글 수에서 제외
+     */
+    public function test_dashboard_loads_soft_deleted_comments_excluded(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('acme');
+        $category = $this->createCategory($tenant);
+        $adminUser = $this->createUser($tenant);
+        $this->actingAs($adminUser);
+
+        $post = $this->createPost($tenant, $category, $adminUser, '인기글', 1, PostState::PUBLISHED->value);
+        $comment = $this->createComments($post[0], CommentState::APPROVED->value, 2);
+
+        model(CommentModel::class)->delete($comment[0]->id);
+
+        // When:
+        $response = $this->get("{$tenant->subdomain}/admin");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('1', 'div[data-testid=widget-popular-posts]');
     }
 
     /**
@@ -167,14 +245,14 @@ class TenantAdminDashboardTest extends CIUnitTestCase
         return fake(CategoryModel::class, ['tenant_id' => $tenant->id]);
     }
 
-    private function createPost($tenant, $category, $user, $title, $count = 1): array
+    private function createPost($tenant, $category, $user, $title, $count = 1, $state = PostState::PUBLISHED->value): array
     {
         $fabricator = new Fabricator(PostModel::class);
         $fabricator->setOverrides([
             'tenant_id'   => $tenant->id,
             'category_id' => $category->id,
             'writer_id'   => $user->id,
-            'state'       => PostState::PUBLISHED->value,
+            'state'       => $state,
             'title'       => $title
         ]);
 
@@ -186,10 +264,17 @@ class TenantAdminDashboardTest extends CIUnitTestCase
         return fake(UserModel::class, ['tenant_id' => $tenant->id])->addGroup('admin');
     }
 
-    private function createComments($post, $count = 1)
+    private function createComments($post, $state, $count = 1): array
     {
+        $comments = [];
+
         for ($i = 0; $i < $count; $i++) {
-            fake(CommentModel::class, ['post_id' => $post->id]);
+            $comments[] = fake(CommentModel::class, [
+                'post_id' => $post->id,
+                'state'   => $state,
+            ]);
         }
+
+        return $comments;
     }
 }

--- a/tests/feature/TenantAdminDashboardTest.php
+++ b/tests/feature/TenantAdminDashboardTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Enums\PostState;
 use App\Models\CategoryModel;
+use App\Models\CommentModel;
 use App\Models\PostModel;
 use App\Models\TenantModel;
 use App\Models\UserModel;
@@ -34,16 +36,19 @@ class TenantAdminDashboardTest extends CIUnitTestCase
 
         $this->actingAs($adminUser);
 
-        $this->createPost($tenant, $category, $adminUser, $postCount);
+        $this->createPost($tenant, $category, $adminUser, '대시보드 테스트용 포스트', $postCount);
 
         // When:
         $response = $this->get("{$tenant->subdomain}/admin");
 
         // Then:
         $response->assertStatus(200);
-        $response->assertSee((string) $postCount, 'div[data-testid=stat-posts]');
+        $response->assertSee((string)$postCount, 'div[data-testid=stat-posts]');
     }
 
+    /**
+     * @test 대시보드 격리 테스트
+     */
     public function test_isolate_dashboard(): void
     {
         // Given:
@@ -59,8 +64,8 @@ class TenantAdminDashboardTest extends CIUnitTestCase
         $userA = $this->createUser($tenantA);
         $userB = $this->createUser($tenantB);
 
-        $this->createPost($tenantA, $categoryA, $userA, $postCountA);
-        $this->createPost($tenantB, $categoryB, $userB, $postCountB);
+        $this->createPost($tenantA, $categoryA, $userA, 'A사 포스트', $postCountA);
+        $this->createPost($tenantB, $categoryB, $userB, 'B사 포스트', $postCountB);
 
         // When:
         $this->actingAs($userA);
@@ -69,8 +74,84 @@ class TenantAdminDashboardTest extends CIUnitTestCase
 
         // Then:
         $response->assertStatus(200);
-        $response->assertSee((string) $postCountA, 'div[data-testid=stat-posts]');
-        $response->assertDontSee((string) ($postCountA + $postCountB), 'div[data-testid=stat-posts]');
+        $response->assertSee((string)$postCountA, 'div[data-testid=stat-posts]');
+        $response->assertDontSee((string)($postCountA + $postCountB), 'div[data-testid=stat-posts]');
+    }
+
+    /**
+     * @test 대시보드 최근 게시물 로드 테스트
+     */
+    public function test_dashboard_loads_recent_posts(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('acme');
+        $category = $this->createCategory($tenant);
+        $adminUser = $this->createUser($tenant);
+
+        $this->actingAs($adminUser);
+
+        $title = '나의 테스트 포스트';
+
+        $this->createPost($tenant, $category, $adminUser, $title);
+
+        // When:
+        $response = $this->get("{$tenant->subdomain}/admin");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee($title, 'div[data-testid=widget-recent-posts]');
+    }
+
+    /**
+     * @test 대시보드 최근 댓글 로드 테스트
+     */
+    public function test_dashboard_loads_recent_comments(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('acme');
+        $category = $this->createCategory($tenant);
+        $adminUser = $this->createUser($tenant);
+
+        $this->actingAs($adminUser);
+
+        $title = '나의 테스트 포스트';
+
+        $post = $this->createPost($tenant, $category, $adminUser, $title);
+
+        $this->createComments($post[0]);
+
+        // When:
+        $response = $this->get("{$tenant->subdomain}/admin");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee($title, 'div[data-testid=widget-recent-comments]');
+    }
+
+    /**
+     * @test 대시보드 인기 포스트 로드 테스트
+     */
+    public function test_dashboard_loads_popular_post(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('acme');
+        $category = $this->createCategory($tenant);
+        $adminUser = $this->createUser($tenant);
+
+        $this->actingAs($adminUser);
+
+        $popularPost = $this->createPost($tenant, $category, $adminUser, '인기글');
+        $quietPost = $this->createPost($tenant, $category, $adminUser, '조용한 글');
+
+        $this->createComments($popularPost[0], 3);
+
+        // When:
+        $response = $this->get("{$tenant->subdomain}/admin");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('인기글', 'div[data-testid=widget-popular-posts]');
+        $response->assertDontSee('조용한 글', 'div[data-testid=widget-popular-posts]');
     }
 
     /**
@@ -86,20 +167,29 @@ class TenantAdminDashboardTest extends CIUnitTestCase
         return fake(CategoryModel::class, ['tenant_id' => $tenant->id]);
     }
 
-    private function createPost($tenant, $category, $user, $count): void
+    private function createPost($tenant, $category, $user, $title, $count = 1): array
     {
         $fabricator = new Fabricator(PostModel::class);
         $fabricator->setOverrides([
             'tenant_id'   => $tenant->id,
             'category_id' => $category->id,
             'writer_id'   => $user->id,
+            'state'       => PostState::PUBLISHED->value,
+            'title'       => $title
         ]);
 
-        $fabricator->create($count);
+        return $fabricator->create($count);
     }
 
     private function createUser($tenant): object
     {
         return fake(UserModel::class, ['tenant_id' => $tenant->id])->addGroup('admin');
+    }
+
+    private function createComments($post, $count = 1)
+    {
+        for ($i = 0; $i < $count; $i++) {
+            fake(CommentModel::class, ['post_id' => $post->id]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
#15 1차(통계 위젯, PR #159) 후속. 어드민 대시보드(`/{tenant}/admin/`)에 활동/순위 위젯 3개를 추가합니다.

- **PostModel**: `popularByComments()` (댓글수 기준 인기 순위), `recent()` (최신 포스트) — 모두 `tenant_id` + `state=published` 스코프
- **CommentModel**: `recent()` — `comments`에 `tenant_id`가 없어 `posts` JOIN 경유로 테넌트 스코프, `post_title`/`post_slug` 동반 select
- **DashboardController**: 위 3개 조회 후 뷰에 `popularPosts`/`recentPosts`/`recentComments` + `tenant` 전달
- **dashboard/index.php**: DaisyUI `stat` 위젯 3개, 1차 패턴대로 `data-testid` 부여 (`widget-popular-posts`/`widget-recent-posts`/`widget-recent-comments`)
- **TenantAdminDashboardTest**: 위젯 로드 테스트 3건 — 인기 포스트는 양성(`인기글` 노출) + 음성(`조용한 글` 미노출) 짝 단언으로 정렬/집계 검증

## 결정 사항
- 인기 순위는 **댓글수 기준만** 구현. 이슈의 "조회수" 기준은 포스트 조회수 컬럼/수집 인프라가 없어 제외
- 댓글 테넌트 스코프는 1차와 동일하게 `posts` JOIN으로 일관 처리

## 남은 작업 (후속 분리)
- 조회수 기반 인기 순위 (조회수 수집 인프라 선행 필요)
- 차트 시각화(Chart.js) / 집계 캐싱 — 대시보드 3차

Closes #160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 대시보드에 세 개의 새로운 위젯 추가: 인기 게시물(댓글 수 기준, 댓글 수 표시), 최신 게시물, 최신 댓글
  * 위젯 목록은 각 항목 링크·제목과 작성일(최근 항목에 표시)을 렌더링

* **테스트**
  * 위젯 노출 및 테넌트 격리 검증 테스트 추가
  * 최신 댓글 위젯에서 미승인·초안 포스트 댓글·소프트 삭제된 댓글을 제외하는 케이스 검증 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->