### PR TITLE
✨ feat: 대시보드 3차 - 활동 추이 차트 + 집계 캐싱 (#161)

### DIFF
--- a/app/Controllers/Tenant/Admin/DashboardController.php
+++ b/app/Controllers/Tenant/Admin/DashboardController.php
@@ -5,6 +5,7 @@ namespace App\Controllers\Tenant\Admin;
 use App\Models\CommentModel;
 use App\Models\PostModel;
 use App\Models\UserModel;
+use CodeIgniter\I18n\Time;
 
 class DashboardController extends BaseAdminController
 {
@@ -34,6 +35,8 @@ class DashboardController extends BaseAdminController
         $recentComments = model(CommentModel::class)
             ->recent($tenant->id, 5);
 
+        $trend = $this->buildTrend($tenant->id);
+
         return $this->adminView(
             'tenant/admin/dashboard/index',
             [
@@ -45,8 +48,28 @@ class DashboardController extends BaseAdminController
                 'popularPosts'   => $popularPosts,
                 'tenant'         => $tenant,
                 'recentPosts'    => $recentPosts,
-                'recentComments' => $recentComments
+                'recentComments' => $recentComments,
+                'trend'          => $trend,
             ]
         );
+    }
+
+    private function buildTrend(int $tenantId, int $days = 30): array
+    {
+        $postMap = model(PostModel::class)->dailyCountsByTenant($tenantId, $days);
+        $commentsMap = model(CommentModel::class)->dailyCountsByTenant($tenantId, $days);
+
+        $labels = [];
+        $posts = [];
+        $comments = [];
+
+        for ($i = $days - 1; $i >= 0; $i--) {
+            $date = Time::now()->subDays($i)->format('Y-m-d');
+            $labels[] = $date;
+            $posts[] = $postMap[$date] ?? 0;
+            $comments[] = $commentsMap[$date] ?? 0;
+        }
+
+        return compact('labels', 'posts', 'comments');
     }
 }

--- a/app/Controllers/Tenant/Admin/DashboardController.php
+++ b/app/Controllers/Tenant/Admin/DashboardController.php
@@ -35,7 +35,9 @@ class DashboardController extends BaseAdminController
         $recentComments = model(CommentModel::class)
             ->recent($tenant->id, 5);
 
-        $trend = $this->buildTrend($tenant->id);
+        $trend = cache()->remember("dashboard_trend_{$tenant->id}", 600, function () use ($tenant) {
+            return $this->buildTrend($tenant->id);
+        });
 
         return $this->adminView(
             'tenant/admin/dashboard/index',

--- a/app/Models/CommentModel.php
+++ b/app/Models/CommentModel.php
@@ -50,7 +50,7 @@ class CommentModel extends Model
 
         $post = (new Fabricator(PostModel::class))
             ->setOverrides([
-                'tenant_id' => $tenant->id,
+                'tenant_id'   => $tenant->id,
                 'category_id' => $category->id,
             ])
             ->create();
@@ -131,5 +131,29 @@ class CommentModel extends Model
             ->orderBy('comments.id', 'DESC')
             ->limit($limit)
             ->findAll();
+    }
+
+    /**
+     * 댓글 수 조회
+     */
+    public function dailyCountsByTenant(int $tenantId, int $days = 30): array
+    {
+        $days -= 1;
+        $from = date('Y-m-d', strtotime("-{$days} days"));
+        $table = $this->db->prefixTable('comments');
+
+        $rows = $this->select("DATE({$table}.created_at) as day, COUNT(*) as cnt", false)
+            ->join('posts', 'posts.id = comments.post_id')
+            ->where('posts.tenant_id', $tenantId)
+            ->where('comments.created_at >=', $from)
+            ->where('comments.deleted_at', null)
+            ->groupBy('day')
+            ->orderBy('day', 'ASC')
+            ->get()
+            ->getResultArray();
+
+        $map = array_column($rows, 'cnt', 'day');
+
+        return array_map('intval', $map);
     }
 }

--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -258,4 +258,30 @@ class PostModel extends Model
             ->limit($limit)
             ->findAll();
     }
+
+
+    /**
+     * 게시물 수 조회
+     *
+     * @param int $tenantId
+     * @param int $days
+     * @return array
+     */
+    public function dailyCountsByTenant(int $tenantId, int $days =  30): array
+    {
+        $days = $days - 1;
+        $from = date('Y-m-d', strtotime("-{$days} days"));
+
+        $rows = $this->select("DATE(created_at) as day, COUNT(*) as cnt", false)
+            ->where('posts.tenant_id', $tenantId)
+            ->where('created_at >=', $from)
+            ->groupBy('day')
+            ->orderBy('day', 'ASC')
+            ->get()
+            ->getResultArray();
+
+        $map = array_column($rows, 'cnt', 'day');
+
+        return array_map('intval', $map);
+    }
 }

--- a/app/Views/tenant/admin/dashboard/index.php
+++ b/app/Views/tenant/admin/dashboard/index.php
@@ -87,10 +87,37 @@
         data: {
             labels: <?= json_encode($trend['labels']) ?>,
             datasets: [
-                { label: '포스트', data: <?= json_encode($trend['posts']) ?> },
-                { label: '댓글', data: <?= json_encode($trend['comments']) ?> },
+                {
+                    label: '포스트',
+                    data: <?= json_encode($trend['posts']) ?>,
+                    borderColor: '#5E81AC',
+                    backgroundColor: '#5E81AC',
+                    tension: 0.3,
+                },
+                {
+                    label: '댓글',
+                    data: <?= json_encode($trend['comments']) ?>,
+                    borderColor: '#BF616A',
+                    backgroundColor: '#BF616A',
+                    tension: 0.3,
+                },
             ]
-        }
+        },
+        options: {
+            responsive: true,
+            scales: {
+                x: { title: { display: true, text: '날짜' } },
+                y: { title: { display: true, text: '개수' }, beginAtZero: true, ticks: { precision: 0 } },
+            },
+            plugins: {
+                legend: { position: 'top' },
+                tooltip: {
+                    callbacks: {
+                        label: (context) => `${context.dataset.label}: ${context.parsed.y}건`,
+                    },
+                },
+            },
+        },
     });
 </script>
 <?= $this->endSection() ?>

--- a/app/Views/tenant/admin/dashboard/index.php
+++ b/app/Views/tenant/admin/dashboard/index.php
@@ -70,6 +70,27 @@
                 <?php endforeach; ?>
             </div>
         </div>
+        <div class="shadow bg-nord-6 rounded-md p-4 md:col-span-3">
+            <h2 class="text-nord-3 mb-2">최근 30일 활동 추이</h2>
+            <canvas data-testid="chart-activity-trend"></canvas>
+        </div>
     </div>
 </div>
+<?= $this->endSection() ?>
+
+<?= $this->section('scripts') ?>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script>
+    const ctx = document.querySelector('[data-testid="chart-activity-trend"]');
+    new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: <?= json_encode($trend['labels']) ?>,
+            datasets: [
+                { label: '포스트', data: <?= json_encode($trend['posts']) ?> },
+                { label: '댓글', data: <?= json_encode($trend['comments']) ?> },
+            ]
+        }
+    });
+</script>
 <?= $this->endSection() ?>

--- a/public/assets/css/output.css
+++ b/public/assets/css/output.css
@@ -4197,12 +4197,12 @@ input.tab:checked + .tab-content,
   border-radius: 0.5rem;
 }
 
-.rounded-xl {
-  border-radius: 0.75rem;
-}
-
 .rounded-md {
   border-radius: 0.375rem;
+}
+
+.rounded-xl {
+  border-radius: 0.75rem;
 }
 
 .border {
@@ -4473,6 +4473,10 @@ input.tab:checked + .tab-content,
 
 .p-2 {
   padding: 0.5rem;
+}
+
+.p-4 {
+  padding: 1rem;
 }
 
 .p-6 {
@@ -4866,11 +4870,6 @@ input.tab:checked + .tab-content,
 
 .text-white\/80 {
   color: rgb(255 255 255 / 0.8);
-}
-
-.text-gray-600 {
-  --tw-text-opacity: 1;
-  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
 }
 
 .underline {
@@ -5568,6 +5567,11 @@ html.theme-transitioning *::after {
   color: rgb(43 102 116 / var(--tw-text-opacity, 1));
 }
 
+.hover\:text-nord-1:hover {
+  --tw-text-opacity: 1;
+  color: rgb(59 66 82 / var(--tw-text-opacity, 1));
+}
+
 .hover\:text-nord-10:hover {
   --tw-text-opacity: 1;
   color: rgb(94 129 172 / var(--tw-text-opacity, 1));
@@ -5707,6 +5711,10 @@ html.theme-transitioning *::after {
 }
 
 @media (min-width: 768px) {
+  .md\:col-span-3 {
+    grid-column: span 3 / span 3;
+  }
+
   .md\:block {
     display: block;
   }

--- a/tests/feature/TenantAdminDashboardTest.php
+++ b/tests/feature/TenantAdminDashboardTest.php
@@ -255,7 +255,7 @@ class TenantAdminDashboardTest extends CIUnitTestCase
         // Then:
         $response->assertStatus(200);
         $response->assertSee('chart-activity-trend');
-        $response->assertSee(date('Y-m-d'));
+        $response->assertSee(Time::now()->format('Y-m-d'));
     }
 
     /**

--- a/tests/feature/TenantAdminDashboardTest.php
+++ b/tests/feature/TenantAdminDashboardTest.php
@@ -9,6 +9,7 @@ use App\Models\CommentModel;
 use App\Models\PostModel;
 use App\Models\TenantModel;
 use App\Models\UserModel;
+use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Test\AuthenticationTesting;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
@@ -230,6 +231,57 @@ class TenantAdminDashboardTest extends CIUnitTestCase
         // Then:
         $response->assertStatus(200);
         $response->assertSee('1', 'div[data-testid=widget-popular-posts]');
+    }
+
+    /**
+     * @test 대시보드 활동 추이 차트 렌더
+     */
+    public function test_dashboard_renders_activity_trend_chart(): void
+    {
+        // Given:
+        cache()->clean();
+
+        $tenant = $this->createTenant('acme');
+        $category = $this->createCategory($tenant);
+        $user = $this->createUser($tenant);
+
+        $this->actingAs($user);
+
+        $this->createPost($tenant, $category, $user, '추이 테스트', 7);
+
+        // When:
+        $response = $this->get("{$tenant->subdomain}/admin");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('chart-activity-trend');
+        $response->assertSee(date('Y-m-d'));
+    }
+
+    /**
+     * @test 활동 추이 30일 0 체움
+     */
+    public function test_dashboard_trend_fills_zero_for_empty_days(): void
+    {
+        // Given:
+        cache()->clean();
+
+        $tenant = $this->createTenant('acme');
+        $category = $this->createCategory($tenant);
+        $user = $this->createUser($tenant);
+
+        $this->actingAs($user);
+
+        $this->createPost($tenant, $category, $user, '오늘 포스트', 1);
+
+        $emptyDay = Time::now()->subDays(29)->format('Y-m-d');
+
+        // When:
+        $response = $this->get("{$tenant->subdomain}/admin");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee($emptyDay);
     }
 
     /**

--- a/tests/unit/CommentModelTest.php
+++ b/tests/unit/CommentModelTest.php
@@ -35,7 +35,7 @@ class CommentModelTest extends CIUnitTestCase
         $this->post = fake(PostModel::class, [
             'tenant_id'   => $this->tenant->id,
             'category_id' => $this->category->id,
-            'writer_d'    => $this->user->id
+            'writer_id'   => $this->user->id
         ]);
     }
 

--- a/tests/unit/CommentModelTest.php
+++ b/tests/unit/CommentModelTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\CategoryModel;
+use App\Models\CommentModel;
+use App\Models\PostModel;
+use App\Models\TenantModel;
+use App\Models\UserModel;
+use CodeIgniter\I18n\Time;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+
+class CommentModelTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    protected $migrate = true;
+    protected $DBGroup = 'tests';
+    protected $namespace = null;
+    protected $tenant;
+    protected $category;
+    protected $user;
+    protected $post;
+    protected $model;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->model = new CommentModel($this->db);
+        $this->tenant = fake(TenantModel::class, ['subdomain' => 'acme', 'name' => 'Acme']);
+        $this->category = fake(CategoryModel::class, ['tenant_id' => $this->tenant->id]);
+        $this->user = fake(UserModel::class, ['tenant_id' => $this->tenant->id]);
+        $this->post = fake(PostModel::class, [
+            'tenant_id'   => $this->tenant->id,
+            'category_id' => $this->category->id,
+            'writer_d'    => $this->user->id
+        ]);
+    }
+
+    /**
+     * @test 날짜별 집계
+     */
+    public function test_comment_daily_count(): void
+    {
+        // Given:
+        $today = Time::now();
+        $yesterday = $today->subDays(1);
+        $twoDaysAgo = $today->subDays(2);
+
+        $this->createComment($today);
+        $this->createComment($yesterday);
+        $this->createComment($twoDaysAgo);
+
+        // When:
+        $result = $this->model->dailyCountsByTenant($this->tenant->id, 30);
+
+        // Then:
+        $this->assertArrayHasKey($today->format('Y-m-d'), $result);
+        $this->assertEquals(1, $result[$today->format('Y-m-d')]);
+        $this->assertCount(3, $result);
+    }
+
+    /**
+     * @test 날짜별 집계 sofeDelete 제외
+     */
+    public function test_comment_daily_count_without_soft_delete(): void
+    {
+        // Given:
+        $today = Time::now();
+        $yesterday = $today->subDays(1);
+        $twoDaysAgo = $today->subDays(2);
+
+        $keep = $this->createComment($today);
+        $delete = $this->createComment($today);
+        $this->createComment($yesterday);
+        $this->createComment($twoDaysAgo);
+
+        $this->model->delete($delete->id);
+
+        // When:
+        $result = $this->model->dailyCountsByTenant($this->tenant->id, 30);
+
+        // Then:
+        $this->assertArrayHasKey($today->format('Y-m-d'), $result);
+        $this->assertEquals(1, $result[$today->format('Y-m-d')]);
+        $this->assertCount(3, $result);
+    }
+
+    /**
+     * helper method
+     */
+    private function createComment($createdAt): object
+    {
+        $comment = fake(CommentModel::class, [
+            'post_id'   => $this->post->id,
+            'writer_id' => $this->user->id
+        ]);
+
+        $this->db->table('comments')
+            ->where('id', $comment->id)
+            ->update(['created_at' => $createdAt->toDateTimeString()]);
+
+        return $comment;
+    }
+}

--- a/tests/unit/PostModelTest.php
+++ b/tests/unit/PostModelTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\CategoryModel;
+use App\Models\PostModel;
+use App\Models\TenantModel;
+use App\Models\UserModel;
+use CodeIgniter\I18n\Time;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+
+class PostModelTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    protected $migrate = true;
+    protected $DBGroup = 'tests';
+    protected $namespace = null;
+    protected $model;
+    protected $tenant;
+    protected $category;
+    protected $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->model = new PostModel($this->db);
+        $this->tenant = fake(TenantModel::class, ['subdomain' => 'acme', 'name' => 'Acme']);
+        $this->category = fake(CategoryModel::class, ['tenant_id' => $this->tenant->id]);
+        $this->user = fake(UserModel::class, ['tenant_id' => $this->tenant->id]);
+    }
+
+    /**
+     * @test 날짜별 포스트 집계
+     */
+    public function test_post_daily_count_by_tenant(): void
+    {
+        // Given:
+        $today = Time::now();
+        $yesterday = $today->subDays(1);
+        $twoDaysAgo = $today->subDays(2);
+
+        $this->createPost($today);
+        $this->createPost($yesterday);
+        $this->createPost($twoDaysAgo);
+
+        // When:
+        $result = $this->model->dailyCountsByTenant($this->tenant->id, 30);
+
+        // Then:
+        $this->assertArrayHasKey($today->format('Y-m-d'), $result);
+        $this->assertEquals(1, $result[$today->format('Y-m-d')]);
+        $this->assertCount(3,  $result);
+    }
+
+    private function createPost($createdAt)
+    {
+        $post = fake(PostModel::class, [
+            'tenant_id'   => $this->tenant->id,
+            'category_id' => $this->category->id,
+            'writer_id'   => $this->user->id,
+        ]);
+
+        $this->db->table('posts')
+            ->where('id', $post->id)
+            ->update(['created_at' => $createdAt->toDateTimeString()]);
+
+        return $post;
+    }
+}


### PR DESCRIPTION
## Summary

테넌트 어드민 대시보드에 **최근 30일 포스트·댓글 활동 추이** Chart.js 라인 차트를 추가하고, 집계 결과를 테넌트별 TTL 캐싱한다. (#15 대시보드 시리즈 3차)

- **모델 집계** — `PostModel`/`CommentModel`에 `dailyCountsByTenant(tenantId, days)` 추가. 날짜별 GROUP BY로 희소 맵 반환(순수 집계)
- **컨트롤러 조립** — `DashboardController::buildTrend()`가 희소 맵을 30일 연속 데이터로 0채움 + Chart.js용 평행 배열(`labels/posts/comments`)로 변환
- **캐싱** — `cache()->remember("dashboard_trend_{tenantId}", 600, ...)` TTL 600초, 테넌트별 키 격리
- **뷰** — Chart.js CDN(@4) + `canvas[data-testid=chart-activity-trend]` 2축 라인 차트, `section('scripts')` 주입
- **테스트** — 모델 일별 집계 단위 테스트(날짜경계/소프트삭제 제외) + 차트 렌더·0채움 Feature 테스트

Closes #161

## 주요 설계 결정

- **책임 분리**: 모델은 순수 집계(희소 맵), 날짜범위·0채움은 컨트롤러 책임 → 모델에서 Time/날짜 의존 제거
- **state 미필터**: 추이는 기존 카운트 위젯과 동일 규칙(포스트 전체 / 댓글은 소프트삭제만 제외)
- **캐싱은 TTL만**(무효화 없음): 카운트 위젯은 실시간, 추이만 10분 캐시
- **raw select 접두사**: `db->prefixTable()`로 DBPrefix 안전 처리 (escape=false 시 접두사 미적용 함정 회피)

## 기술 부채 / 후속 (이번 PR 범위 외)

- 캐시 무효화 없음 — 글 발행 직후 최대 10분 차트 지연(설계상 의도). 즉시성이 필요해지면 "발행 시 캐시 무효화" 별도 이슈로 분리
- Chart.js CDN 의존 — 오프라인/엄격 CSP 환경에선 npm 번들 전환 고려(현재는 의도된 단순화)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자 대시보드에 최근 30일 활동 추이 차트를 추가했습니다. 포스트와 댓글의 일별 증감을 라인 차트로 시각적으로 확인할 수 있습니다.

* **Tests**
  * 활동 추이 차트 렌더링 및 데이터 집계 로직에 대한 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->