### PR TITLE
✨ feat: 대시보드 빠른 액션 위젯 (#162)

### DIFF
--- a/app/Views/tenant/admin/dashboard/index.php
+++ b/app/Views/tenant/admin/dashboard/index.php
@@ -11,6 +11,15 @@
             <h1 class="text-2xl font-bold text-nord-0">대시보드</h1>
         </div>
     </div>
+    <div class="card bg-nord-6 w-full shadow-sm">
+        <div class="card-body">
+            <h2 class="card-title">빠른 액션</h2>
+            <div class="card-actions justify-end">
+                <a href="<?= esc(site_url("{$tenant->subdomain}/admin/media"), 'attr') ?>" class="btn btn-primary">미디어 추가</a>
+                <a href="<?= esc(site_url("{$tenant->subdomain}/"), 'attr') ?>" class="btn btn-outline">사이트 보기</a>
+            </div>
+        </div>
+    </div>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div class="stat shadow bg-nord-6 rounded-md">


### PR DESCRIPTION
## Summary
어드민 대시보드 상단에 **빠른 액션** 카드를 추가했습니다. 자주 쓰는 페이지로 바로 이동하는 버튼 위젯입니다.

- 미디어 라이브러리 (`admin/media`) — 주 액션 (`btn-primary`)
- 사이트 보기 (테넌트 공개 홈 `{slug}/`) — `btn-outline`

`#15` 대시보드 시리즈(1차 통계 → 2차 최근활동/인기포스트 → 3차 활동추이) 후속인 `#162`(운영 위젯)의 **1차(빠른 액션)** 작업입니다.

## 결정
- 어드민 CRUD 화면이 **미디어 라이브러리(#12)만** 구현돼 있어, 깨진 링크(404)를 피하기 위해 **실제 동작하는 링크만** 노출했습니다.
- 글쓰기·카테고리 바로가기는 해당 어드민 화면 구현 후 추가 예정.
- 사용한 DaisyUI 클래스(card/btn-outline 등)는 이미 `output.css`에 빌드돼 있어 CSS 재빌드 불필요.

## 부채 / 후속
- #166 — 테넌트 어드민 Posts/Categories 등 CRUD 화면 미구현 (빠른 액션 확장의 선행 조건)
- #162 나머지 항목(알림/공지, 시스템 상태, 방문자 통계)은 별도 차수로 진행

## 진행
Refs #162 (1차 빠른 액션만 — 묶음 이슈이므로 머지해도 #162는 열어둠)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 대시보드 상단에 "빠른 액션" 카드를 추가하여 자주 사용하는 작업에 빠르게 접근할 수 있게 개선했습니다.
  * "미디어 추가" 및 "사이트 보기" 링크를 통해 주요 작업을 원클릭으로 실행 가능하도록 구현했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->