### PR TITLE
✨ feat: 테넌트 어드민 카테고리 CRUD (#166)

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -130,7 +130,6 @@ $routes->group('([a-z0-9][a-z0-9\-]{0,61})', ['filter' => 'tenant'], static func
     $routes->group('admin', ['filter' => 'group:admin,superadmin'], static function ($routes): void {
         $routes->get('/', 'Tenant\Admin\DashboardController::index/$1');
         $routes->resource('pages', ['controller' => 'Tenant\Admin\PagesController']);
-        $routes->resource('categories', ['controller' => 'Tenant\Admin\CategoriesController']);
         $routes->resource('tags', ['controller' => 'Tenant\Admin\TagsController']);
         $routes->resource('comments', ['controller' => 'Tenant\Admin\CommentsController']);
         $routes->resource('media', ['controller' => 'Tenant\Admin\MediaController']);
@@ -147,5 +146,12 @@ $routes->group('([a-z0-9][a-z0-9\-]{0,61})', ['filter' => 'tenant'], static func
         $routes->get('posts/(:num)/edit', 'Tenant\Admin\PostsController::edit/$2');
         $routes->put('posts/(:num)', 'Tenant\Admin\PostsController::update/$2');
         $routes->delete('posts/(:num)', 'Tenant\Admin\PostsController::delete/$2');
+
+        $routes->get('categories', 'Tenant\Admin\CategoriesController::index');
+        $routes->get('categories/new', 'Tenant\Admin\CategoriesController::new');
+        $routes->post('categories', 'Tenant\Admin\CategoriesController::create');
+        $routes->get('categories/(:num)/edit', 'Tenant\Admin\CategoriesController::edit/$2');
+        $routes->put('categories/(:num)', 'Tenant\Admin\CategoriesController::update/$2');
+        $routes->delete('categories/(:num)', 'Tenant\Admin\CategoriesController::delete/$2');
     });
 });

--- a/app/Controllers/Tenant/Admin/CategoriesController.php
+++ b/app/Controllers/Tenant/Admin/CategoriesController.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Controllers\Tenant\Admin;
+
+use App\Models\CategoryModel;
+use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use ReflectionException;
+
+class CategoriesController extends BaseAdminController
+{
+    protected $tenant;
+    protected CategoryModel $categoryModel;
+    protected $indexPage;
+    protected $rules = [
+        'name'        => 'required|max_length[255]',
+        'description' => 'permit_empty|string',
+    ];
+
+    public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
+    {
+        parent::initController($request, $response, $logger);
+
+        $this->tenant = service('tenant')->getTenant();
+        $this->indexPage = "/{$this->tenant->subdomain}/admin/categories";
+        $this->categoryModel = model(CategoryModel::class);
+    }
+
+
+    /**
+     * 카테고리 목록
+     * @return string
+     */
+    public function index(): string
+    {
+        $categories = $this->categoryModel
+            ->where('tenant_id', $this->tenant->id)
+            ->orderBy('created_at', 'DESC')
+            ->findAll();
+
+        return $this->adminView('tenant/admin/categories/index', [
+            'subdomain'  => $this->tenant->subdomain,
+            'categories' => $categories,
+            'activeMenu' => 'categories',
+            'pageTitle'  => '카테고리',
+        ]);
+    }
+
+
+    /**
+     * 카테고리 생성 Form
+     * @return string
+     */
+    public function new(): string
+    {
+        return $this->adminView('tenant/admin/categories/new', [
+            'subdomain' => $this->tenant->subdomain,
+            'activeMenu' => 'categories',
+            'pageTitle'  => '카테고리 생성',
+        ]);
+    }
+
+    /**
+     * 카테고리 생성
+     * @return RedirectResponse
+     * @throws ReflectionException
+     */
+    public function create(): RedirectResponse
+    {
+        if (!$this->validate($this->rules)) {
+            return redirect()
+                ->back()
+                ->withInput()
+                ->with('errors', $this->validator->getErrors());
+        }
+
+        $result = $this->categoryModel->insert([
+            'tenant_id'   => $this->tenant->id,
+            'name'        => $this->request->getPost('name'),
+            'description' => $this->request->getPost('description'),
+        ]);
+
+        if ($result === false) {
+            return redirect()
+                ->back()
+                ->withInput()
+                ->with('errors', $this->categoryModel->errors());
+        }
+
+        return redirect()->to($this->indexPage);
+    }
+
+    /**
+     * 카테고리 수정 Form
+     * @param $id
+     * @return string
+     */
+    public function edit($id): string
+    {
+        $category = $this->getCategory($id);
+
+        return $this->adminView('tenant/admin/categories/edit', [
+            'subdomain'    => $this->tenant->subdomain,
+            'activeMenu'   => 'categories',
+            'pageTitle'    => '카테고리 수정',
+            'category'     => $category,
+        ]);
+    }
+
+    /**
+     * 카테고리 수정
+     * @param $id
+     * @return RedirectResponse
+     * @throws ReflectionException
+     */
+    public function update($id): RedirectResponse
+    {
+        $this->getCategory($id);
+
+        if (!$this->validate($this->rules)) {
+            return redirect()
+                ->back()
+                ->withInput()
+                ->with('errors', $this->validator->getErrors());
+        }
+
+        $result = $this->categoryModel->update($id, [
+            'name'        => $this->request->getPost('name'),
+            'description' => $this->request->getPost('description'),
+        ]);
+
+        if ($result === false) {
+            return redirect()
+                ->back()
+                ->withInput()
+                ->with('errors', $this->categoryModel->errors());
+        }
+
+        return redirect()->to($this->indexPage);
+    }
+
+    /**
+     * 카테고리 삭제
+     * @param $id
+     * @return RedirectResponse
+     */
+    public function delete($id): RedirectResponse
+    {
+        $this->getCategory($id);
+
+        $result = $this->categoryModel->delete($id);
+
+        if ($result === false) {
+            return redirect()
+                ->back()
+                ->with('errors', ['삭제에 실패했습니다.']);
+        }
+
+        return redirect()->to($this->indexPage);
+    }
+
+    /**
+     * 카테고리 조회 및 소유권 검증 (없으면 404)
+     * @param $id
+     * @return object
+     * @throws PageNotFoundException
+     */
+    protected function getCategory($id): object
+    {
+        $category = $this->categoryModel
+            ->where('tenant_id', $this->tenant->id)
+            ->find($id);
+
+        if (is_null($category)) {
+            throw new PageNotFoundException();
+        }
+
+        return $category;
+    }
+}

--- a/app/Views/tenant/admin/categories/edit.php
+++ b/app/Views/tenant/admin/categories/edit.php
@@ -1,0 +1,64 @@
+<?= $this->extend('layouts/admin') ?>
+
+<?= $this->section('title') ?>
+    카테고리 수정
+<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+    <div class="flex items-center justify-between">
+        <div>
+            <h1 class="text-2xl font-bold text-nord-0">카테고리 수정</h1>
+        </div>
+    </div>
+    <div class="card bg-nord-6 w-full shadow-sm">
+        <div class="card-body">
+            <?php if (session('errors')): ?>
+                <?php foreach (session('errors') as $error): ?>
+                    <div class="alert alert-error">
+                        <div>
+                            <svg xmlns="http://www.w3.org/2000/svg" class="inline stroke-current shrink-0 h-6 w-6"
+                                fill="none" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                            </svg>
+                            <span><?= $error ?></span>
+                        </div>
+                    </div>
+                <?php endforeach ?>
+            <?php endif ?>
+            <form
+                method="post"
+                class="form-control"
+                action="<?= site_url("{$subdomain}/admin/categories/{$category->id}") ?>"
+            >
+                <input type="hidden" name="_method" value="PUT">
+                <?= csrf_field() ?>
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text text-nord-0">이름</span>
+                    </label>
+                    <input
+                        type="text"
+                        placeholder="카테고리 이름을 입력하세요"
+                        class="input input-bordered bg-nord-4"
+                        name="name"
+                        value="<?= old('name', esc($category->name)) ?>"
+                    >
+                </div>
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text text-nord-0">설명</span>
+                    </label>
+                    <textarea
+                        class="textarea textarea-bordered h-24 bg-nord-4"
+                        placeholder="설명을 입력하세요 (선택)"
+                        name="description"
+                    ><?= old('description', esc($category->description)) ?></textarea>
+                </div>
+                <div class="form-control mt-4">
+                    <button class="btn btn-primary">저장</button>
+                </div>
+            </form>
+        </div>
+    </div>
+<?= $this->endSection() ?>

--- a/app/Views/tenant/admin/categories/edit.php
+++ b/app/Views/tenant/admin/categories/edit.php
@@ -21,7 +21,7 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                     d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                             </svg>
-                            <span><?= $error ?></span>
+                            <span><?= esc($error) ?></span>
                         </div>
                     </div>
                 <?php endforeach ?>

--- a/app/Views/tenant/admin/categories/index.php
+++ b/app/Views/tenant/admin/categories/index.php
@@ -25,7 +25,7 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                             d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                     </svg>
-                    <span><?= $error ?></span>
+                    <span><?= esc($error) ?></span>
                 </div>
             </div>
         <?php endforeach ?>

--- a/app/Views/tenant/admin/categories/index.php
+++ b/app/Views/tenant/admin/categories/index.php
@@ -1,0 +1,75 @@
+<?= $this->extend('layouts/admin') ?>
+
+<?= $this->section('title') ?>
+    카테고리
+<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <div>
+            <h1 class="text-2xl font-bold text-nord-0">카테고리</h1>
+            <p class="text-sm text-nord-3 mt-1">카테고리를 관리합니다.</p>
+        </div>
+        <a type="button" class="btn btn-primary" href="<?= site_url("{$subdomain}/admin/categories/new") ?>">
+            새 카테고리
+        </a>
+    </div>
+
+    <?php if (session('errors')): ?>
+        <?php foreach (session('errors') as $error): ?>
+            <div class="alert alert-error">
+                <div>
+                    <svg xmlns="http://www.w3.org/2000/svg" class="inline stroke-current shrink-0 h-6 w-6"
+                        fill="none" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                    </svg>
+                    <span><?= $error ?></span>
+                </div>
+            </div>
+        <?php endforeach ?>
+    <?php endif ?>
+
+    <div class="card bg-nord-6 w-full shadow-sm">
+        <div class="card-body">
+            <div class="overflow-x-auto">
+                <table class="table [&_tr]:border-nord-4">
+                    <!-- head -->
+                    <thead class="text-nord-3">
+                    <tr>
+                        <th></th>
+                        <th>이름</th>
+                        <th>슬러그</th>
+                        <th>설명</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <?php if (empty($categories)) : ?>
+                        <tr><td colspan="5"><div class="text-nord-3 text-center">등록된 카테고리가 없습니다</div></td></tr>
+                    <?php else: ?>
+                        <?php foreach ($categories as $category) : ?>
+                            <tr>
+                                <td class="text-nord-0"><?= $category->id ?></td>
+                                <td class="text-nord-0"><?= esc($category->name) ?></td>
+                                <td class="text-nord-3"><?= esc($category->slug) ?></td>
+                                <td class="text-nord-3"><?= esc($category->description) ?></td>
+                                <td>
+                                    <a href="<?= site_url("{$subdomain}/admin/categories/{$category->id}/edit") ?>" class="btn btn-sm">수정</a>
+                                    <form method="post" action="<?= site_url("{$subdomain}/admin/categories/{$category->id}") ?>">
+                                        <input type="hidden" name="_method" value="DELETE">
+                                        <?= csrf_field() ?>
+                                        <button onclick="return confirm('삭제할까요?')" class="btn btn-error btn-sm">삭제</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach ?>
+                    <?php endif ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+<?= $this->endSection() ?>

--- a/app/Views/tenant/admin/categories/new.php
+++ b/app/Views/tenant/admin/categories/new.php
@@ -21,7 +21,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                     d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                         </svg>
-                        <span><?= $error ?></span>
+                        <span><?= esc($error) ?></span>
                     </div>
                 </div>
             <?php endforeach ?>

--- a/app/Views/tenant/admin/categories/new.php
+++ b/app/Views/tenant/admin/categories/new.php
@@ -1,0 +1,59 @@
+<?= $this->extend('layouts/admin') ?>
+
+<?= $this->section('title') ?>
+카테고리 생성
+<?= $this->endSection() ?>
+
+<?= $this->section('content') ?>
+<div class="flex items-center justify-between">
+    <div>
+        <h1 class="text-2xl font-bold text-nord-0">카테고리 생성</h1>
+    </div>
+</div>
+<div class="card bg-nord-6 w-full shadow-sm">
+    <div class="card-body">
+        <?php if (session('errors')): ?>
+            <?php foreach (session('errors') as $error): ?>
+                <div class="alert alert-error">
+                    <div>
+                        <svg xmlns="http://www.w3.org/2000/svg" class="inline stroke-current shrink-0 h-6 w-6"
+                                fill="none" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                        </svg>
+                        <span><?= $error ?></span>
+                    </div>
+                </div>
+            <?php endforeach ?>
+        <?php endif ?>
+        <form method="post" action="<?= site_url("{$subdomain}/admin/categories") ?>" class="form-control">
+            <?= csrf_field() ?>
+            <div class="form-control">
+                <label class="label">
+                    <span class="label-text text-nord-0">이름</span>
+                </label>
+                <input
+                        type="text"
+                        placeholder="카테고리 이름을 입력하세요"
+                        class="input input-bordered bg-nord-4"
+                        name="name"
+                        value="<?= old('name') ?>"
+                >
+            </div>
+            <div class="form-control">
+                <label class="label">
+                    <span class="label-text text-nord-0">설명</span>
+                </label>
+                <textarea
+                        class="textarea textarea-bordered h-24 bg-nord-4"
+                        placeholder="설명을 입력하세요 (선택)"
+                        name="description"
+                ><?= old('description') ?></textarea>
+            </div>
+            <div class="form-control mt-4">
+                <button class="btn btn-primary">저장</button>
+            </div>
+        </form>
+    </div>
+</div>
+<?= $this->endSection() ?>

--- a/tests/feature/TenantAdminCategoriesTest.php
+++ b/tests/feature/TenantAdminCategoriesTest.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\CategoryModel;
+use App\Models\TenantModel;
+use App\Models\UserModel;
+use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\Shield\Test\AuthenticationTesting;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\FeatureTestTrait;
+
+class TenantAdminCategoriesTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+    use FeatureTestTrait;
+    use AuthenticationTesting;
+
+    protected $refresh = true;
+    protected $namespace = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // 예외(PageNotFoundException)를 던지는 테스트가 공유 서비스(routes/request)를
+        // 더럽혀 뒤따르는 _method 스푸핑 테스트가 깨지는 것을 막는다.
+        $this->resetServices();
+    }
+
+    /**
+     * @test 목록에 카테고리가 표시된다
+     */
+    public function test_index_lists_categories(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('acme');
+        $category = $this->createCategory($tenant, '여행');
+        $this->actingAs($this->createUser($tenant));
+
+        // When:
+        $response = $this->get("{$tenant->subdomain}/admin/categories");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('여행');
+    }
+
+    /**
+     * @test 목록은 다른 테넌트의 카테고리를 노출하지 않는다 (격리)
+     */
+    public function test_index_isolates_other_tenant_categories(): void
+    {
+        // Given:
+        $tenantA = $this->createTenant('acme');
+        $tenantB = $this->createTenant('example');
+
+        $this->createCategory($tenantA, '내카테고리');
+        $this->createCategory($tenantB, '남의카테고리');
+
+        $this->actingAs($this->createUser($tenantA));
+
+        // When:
+        $response = $this->get("{$tenantA->subdomain}/admin/categories");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('내카테고리');        // 양성
+        $response->assertDontSee('남의카테고리');  // 음성
+    }
+
+    /**
+     * @test 작성 폼이 로드된다
+     */
+    public function test_new_form_loads(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('acme');
+        $this->actingAs($this->createUser($tenant));
+
+        // When:
+        $response = $this->get("{$tenant->subdomain}/admin/categories/new");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('카테고리 생성');
+    }
+
+    /**
+     * @test 카테고리를 생성하면 DB에 저장된다
+     */
+    public function test_create_persists_category(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('acme');
+        $this->actingAs($this->createUser($tenant));
+
+        // When:
+        $response = $this->post("{$tenant->subdomain}/admin/categories", [
+            'name'        => '새 카테고리',
+            'description' => '설명입니다',
+        ]);
+
+        // Then:
+        $response->assertRedirect();
+        $this->seeInDatabase('categories', [
+            'tenant_id'   => $tenant->id,
+            'name'        => '새 카테고리',
+            'description' => '설명입니다',
+        ]);
+    }
+
+    /**
+     * @test 이름이 없으면 생성에 실패한다 (검증)
+     */
+    public function test_create_fails_without_name(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('acme');
+        $this->actingAs($this->createUser($tenant));
+
+        // When:
+        $response = $this->post("{$tenant->subdomain}/admin/categories", [
+            'name'        => '',
+            'description' => '이름 없음',
+        ]);
+
+        // Then:
+        $response->assertRedirect();
+        $this->dontSeeInDatabase('categories', [
+            'tenant_id'   => $tenant->id,
+            'description' => '이름 없음',
+        ]);
+    }
+
+    /**
+     * @test 수정 폼에 기존 값이 채워진다
+     */
+    public function test_edit_form_shows_existing_value(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('acme');
+        $category = $this->createCategory($tenant, '수정전이름');
+        $this->actingAs($this->createUser($tenant));
+
+        // When:
+        $response = $this->get("{$tenant->subdomain}/admin/categories/{$category->id}/edit");
+
+        // Then:
+        $response->assertStatus(200);
+        $response->assertSee('수정전이름');
+    }
+
+    /**
+     * @test 다른 테넌트의 카테고리 수정 폼은 404 (IDOR 방어)
+     */
+    public function test_edit_other_tenant_returns_404(): void
+    {
+        // Given:
+        $tenantA = $this->createTenant('acme');
+        $tenantB = $this->createTenant('example');
+        $categoryB = $this->createCategory($tenantB, '남의것');
+
+        $this->actingAs($this->createUser($tenantA));
+
+        // Then:
+        $this->expectException(PageNotFoundException::class);
+
+        // When: A 테넌트로 B 카테고리 수정 시도
+        $this->get("{$tenantA->subdomain}/admin/categories/{$categoryB->id}/edit");
+    }
+
+    /**
+     * @test 카테고리를 수정하면 DB가 갱신된다
+     */
+    public function test_update_changes_category(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('acme');
+        $category = $this->createCategory($tenant, '수정전');
+        $this->actingAs($this->createUser($tenant));
+
+        // When: 실제 폼 흐름(POST + _method=PUT 스푸핑)을 재현
+        $response = $this->submitPut("{$tenant->subdomain}/admin/categories/{$category->id}", [
+            'name'        => '수정후',
+            'description' => '갱신됨',
+        ]);
+
+        // Then:
+        $response->assertRedirect();
+        $this->seeInDatabase('categories', [
+            'id'   => $category->id,
+            'name' => '수정후',
+        ]);
+    }
+
+    /**
+     * @test 다른 테넌트의 카테고리 수정은 404 (IDOR 방어)
+     */
+    public function test_update_other_tenant_returns_404(): void
+    {
+        // Given:
+        $tenantA = $this->createTenant('acme');
+        $tenantB = $this->createTenant('example');
+        $categoryB = $this->createCategory($tenantB, '남의것');
+
+        $this->actingAs($this->createUser($tenantA));
+
+        // Then:
+        $this->expectException(PageNotFoundException::class);
+
+        // When:
+        $this->put("{$tenantA->subdomain}/admin/categories/{$categoryB->id}", [
+            'name' => '탈취시도',
+        ]);
+    }
+
+    /**
+     * @test 카테고리를 삭제하면 DB에서 제거된다
+     */
+    public function test_delete_removes_category(): void
+    {
+        // Given:
+        $tenant = $this->createTenant('acme');
+        $category = $this->createCategory($tenant, '삭제대상');
+        $this->actingAs($this->createUser($tenant));
+
+        // When:
+        $response = $this->delete("{$tenant->subdomain}/admin/categories/{$category->id}");
+
+        // Then:
+        $response->assertRedirect();
+        $this->dontSeeInDatabase('categories', ['id' => $category->id]);
+    }
+
+    /**
+     * @test 다른 테넌트의 카테고리 삭제는 404 (IDOR 방어)
+     */
+    public function test_delete_other_tenant_returns_404(): void
+    {
+        // Given:
+        $tenantA = $this->createTenant('acme');
+        $tenantB = $this->createTenant('example');
+        $categoryB = $this->createCategory($tenantB, '남의것');
+
+        $this->actingAs($this->createUser($tenantA));
+
+        // Then:
+        $this->expectException(PageNotFoundException::class);
+
+        // When:
+        $this->delete("{$tenantA->subdomain}/admin/categories/{$categoryB->id}");
+
+        // And: B의 카테고리는 그대로 남아있다
+        $this->seeInDatabase('categories', ['id' => $categoryB->id]);
+    }
+
+    /**
+     * helper methods
+     */
+    private function createTenant($subdomain): object
+    {
+        return fake(TenantModel::class, ['subdomain' => $subdomain]);
+    }
+
+    private function createCategory($tenant, $name): object
+    {
+        return fake(CategoryModel::class, ['tenant_id' => $tenant->id, 'name' => $name]);
+    }
+
+    private function createUser($tenant): object
+    {
+        return fake(UserModel::class, ['tenant_id' => $tenant->id])->addGroup('admin');
+    }
+
+    /**
+     * HTML 폼의 PUT 제출을 재현한다.
+     *
+     * 브라우저는 POST + hidden _method=PUT 로 보내고, CI4가 메서드를 PUT 으로 스푸핑한다.
+     * 스푸핑 후 Validation::withRequest 는 본문을 getRawInput()(원시 본문)에서 읽으므로,
+     * post 글로벌(getPost용)과 urlencoded 원시 본문(검증용)을 모두 채워야 실제와 동일하다.
+     */
+    private function submitPut(string $url, array $data)
+    {
+        $payload = ['_method' => 'PUT'] + $data;
+
+        return $this->withBody(http_build_query($payload))->post($url, $payload);
+    }
+}


### PR DESCRIPTION
## Summary
Posts CRUD 패턴(#168)을 재사용해 테넌트 어드민 카테고리 화면을 구현합니다.

- **Routes**: `resource('categories')`를 명시적 6줄로 풀어 테넌트 캡쳐그룹 함정 회피 (`edit/$2`)
- **CategoriesController**: `index/new/create/edit/update/delete` + `getCategory()` 소유권 헬퍼
- **뷰 3개**: `index`/`new`/`edit` (edit는 `old()` default를 `esc()`로 감싸 XSS 방어)
- **테스트 11개**: CRUD + 테넌트 격리(IDOR) 양성·음성 단언, 전체 스위트 277개 통과

## 결정
- `getCategory()`는 **"객체 반환 + 없으면 throw"**(findOrFail 관용구). `edit`은 반환값 사용, `update`/`delete`는 가드로 호출해 IDOR 검증을 한 곳에 모음
- 카테고리 삭제 시 연결된 포스트 처리는 별도 이슈(#90 FK 검증 연관)로 분리

## 테스트 함정 해결 (재사용 가치)
- `_method` 스푸핑 후 `Validation::withRequest`는 `getRawInput()`(원시 본문)에서 읽음 → `submitPut` 헬퍼로 `withBody(http_build_query)` + `post()` 조합으로 실제 폼 흐름 재현
- 예외(`PageNotFoundException`) 테스트가 공유 서비스(routes)를 더럽혀 뒤 스푸핑 테스트가 깨지는 순서 의존성 → `setUp`의 `resetServices()`로 격리

## 남은 부채
- `output.css`(#165)는 의도적으로 커밋 제외
- #166 나머지 차수: Tags / Comments / Users / Settings / SEO / Stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 테넌트 관리자 대시보드에 카테고리 관리 기능 추가
  * 카테고리 목록 조회, 생성, 수정, 삭제 기능 지원
  * 각 테넌트는 자신의 카테고리만 접근 및 관리 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->